### PR TITLE
fix(Container): Use Dockerfile.playwright for releases

### DIFF
--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -74,6 +74,7 @@ plugins:
             --annotation "index:org.opencontainers.image.version=${nextRelease.version}" \
             --annotation "index:org.opencontainers.image.title=$TITLE" \
             --tag ghcr.io/$REPO_LOWER:${nextRelease.version} \
+            --file Dockerfile.playwright \
             --push .
         else
           docker buildx build --platform linux/amd64,linux/arm64 \
@@ -87,6 +88,7 @@ plugins:
             --annotation "index:org.opencontainers.image.title=$TITLE" \
             --tag ghcr.io/$REPO_LOWER:${nextRelease.version} \
             --tag ghcr.io/$REPO_LOWER:latest \
+            --file Dockerfile.playwright \
             --push .
         fi
 


### PR DESCRIPTION
Fixes #26 - Container startup failure due to missing Node.js dependency

The issue was that release builds were using the basic Alpine Dockerfile instead of Dockerfile.playwright which includes required browser dependencies.

Generated with [Claude Code](https://claude.ai/code)