### PR TITLE
fix(execute_script): Actionable rejection reasons & fix function-expression false positive

### DIFF
--- a/agent.yaml
+++ b/agent.yaml
@@ -258,7 +258,7 @@ spec:
             type: string
             description: >-
               JavaScript code to execute in the browser (Playwright
-              page.evaluate context). Use DOM/Web APIs only — Node.js
+              page.evaluate context). Use DOM/Web APIs only - Node.js
               built-ins are unavailable.
           args:
             type: array

--- a/agent.yaml
+++ b/agent.yaml
@@ -237,7 +237,15 @@ spec:
         - playwright
     - id: execute_script
       name: execute_script
-      description: Execute custom JavaScript code in the browser context
+      description: >-
+        Execute custom JavaScript inside the current page via Playwright's
+        page.evaluate(). The script runs in the browser context, NOT in Node.js:
+        globals like window, document, navigator, fetch and localStorage are
+        available; Node.js built-ins (require, process, __dirname, __filename,
+        fs, path, os, http, https, child_process, etc.) are NOT available and
+        calls to them will be rejected. Use browser/DOM APIs only. The script
+        body is automatically wrapped in an IIFE, so a top-level `return` is
+        valid. Set async=true if the body uses `await`.
       tags:
         - javascript
         - execution
@@ -248,7 +256,10 @@ spec:
         properties:
           script:
             type: string
-            description: JavaScript code to execute
+            description: >-
+              JavaScript code to execute in the browser (Playwright
+              page.evaluate context). Use DOM/Web APIs only — Node.js
+              built-ins are unavailable.
           args:
             type: array
             items:

--- a/tools/execute_script.go
+++ b/tools/execute_script.go
@@ -58,7 +58,7 @@ func NewExecuteScriptTool(logger *zap.Logger, playwright playwright.BrowserAutom
 			"type": "object",
 			"properties": map[string]any{
 				"script": map[string]any{
-					"description": "JavaScript code to execute in the browser (Playwright page.evaluate context). Use DOM/Web APIs only — Node.js built-ins are unavailable.",
+					"description": "JavaScript code to execute in the browser (Playwright page.evaluate context). Use DOM/Web APIs only - Node.js built-ins are unavailable.",
 					"type":        "string",
 				},
 				"args": map[string]any{
@@ -221,12 +221,12 @@ type dangerousScriptPattern struct {
 // Note: the legacy `function\s*\(` pattern was removed because it matched any
 // JavaScript function expression (including the IIFE this tool itself emits
 // in prepareScript and any user `(function () { ... })()`). The dynamic-code
-// hazard it tried to cover — the `Function` constructor — is now handled by
+// hazard it tried to cover - the `Function` constructor - is now handled by
 // the case-sensitive `\bFunction\s*\(` pattern below.
 var dangerousScriptPatterns = []*dangerousScriptPattern{
 	{
 		pattern: `require\s*\(\s*['"]fs['"]`,
-		reason:  "uses Node.js `require('fs')` for filesystem access; the browser sandbox has no filesystem — there is no equivalent from page.evaluate()",
+		reason:  "uses Node.js `require('fs')` for filesystem access; the browser sandbox has no filesystem - there is no equivalent from page.evaluate()",
 	},
 	{
 		pattern: `require\s*\(\s*['"]path['"]`,
@@ -234,7 +234,7 @@ var dangerousScriptPatterns = []*dangerousScriptPattern{
 	},
 	{
 		pattern: `require\s*\(\s*['"]os['"]`,
-		reason:  "uses Node.js `require('os')`; OS metadata is not exposed to the browser context — inspect `navigator.userAgent` / `navigator.platform` instead",
+		reason:  "uses Node.js `require('os')`; OS metadata is not exposed to the browser context - inspect `navigator.userAgent` / `navigator.platform` instead",
 	},
 	{
 		pattern: `require\s*\(\s*['"]http['"]`,
@@ -265,9 +265,6 @@ var dangerousScriptPatterns = []*dangerousScriptPattern{
 		reason:  "calls `eval(...)`; dynamic code evaluation is blocked. Inline the logic directly instead",
 	},
 	{
-		// Case-sensitive: matches the `Function` constructor (`new Function(...)`
-		// or `Function(...)`) without flagging ordinary `function (...) { ... }`
-		// expressions or IIFEs like `(function () { ... })()`.
 		pattern:       `\bFunction\s*\(`,
 		reason:        "uses the `Function` constructor for dynamic code generation; this is blocked for the same reason as eval. Inline the logic directly instead. (Regular `function () { ... }` expressions and IIFEs are fine.)",
 		caseSensitive: true,

--- a/tools/execute_script.go
+++ b/tools/execute_script.go
@@ -33,6 +33,18 @@ type ScriptExecutionResult struct {
 	Metadata    map[string]any `json:"metadata,omitempty"`
 }
 
+// executeScriptToolDescription is the description shown to the LLM when the
+// tool is registered. It deliberately spells out the browser/Playwright
+// execution context so the model does not waste turns trying Node.js APIs.
+const executeScriptToolDescription = "Execute custom JavaScript inside the current page via Playwright's " +
+	"page.evaluate(). The script runs in the browser context, NOT in Node.js: " +
+	"globals like window, document, navigator, fetch and localStorage are " +
+	"available; Node.js built-ins (require, process, __dirname, __filename, " +
+	"fs, path, os, http, https, child_process, etc.) are NOT available and " +
+	"calls to them will be rejected. Use browser/DOM APIs only. The script " +
+	"body is automatically wrapped in an IIFE, so a top-level `return` is " +
+	"valid. Set async=true if the body uses `await`."
+
 // NewExecuteScriptTool creates a new execute_script tool
 func NewExecuteScriptTool(logger *zap.Logger, playwright playwright.BrowserAutomation) server.Tool {
 	tool := &ExecuteScriptTool{
@@ -41,12 +53,12 @@ func NewExecuteScriptTool(logger *zap.Logger, playwright playwright.BrowserAutom
 	}
 	return server.NewBasicTool(
 		"execute_script",
-		"Execute custom JavaScript code in the browser context",
+		executeScriptToolDescription,
 		map[string]any{
 			"type": "object",
 			"properties": map[string]any{
 				"script": map[string]any{
-					"description": "JavaScript code to execute",
+					"description": "JavaScript code to execute in the browser (Playwright page.evaluate context). Use DOM/Web APIs only — Node.js built-ins are unavailable.",
 					"type":        "string",
 				},
 				"args": map[string]any{
@@ -88,7 +100,7 @@ func (s *ExecuteScriptTool) ExecuteScriptHandler(ctx context.Context, args map[s
 
 	if err := s.validateScriptSecurity(script); err != nil {
 		s.logger.Error("script security validation failed", zap.String("script", script), zap.Error(err))
-		return "", fmt.Errorf("script security validation failed: %w", err)
+		return "", fmt.Errorf("execute_script rejected the script: %w. execute_script runs inside the browser via Playwright page.evaluate(); Node.js built-ins (require, process, fs, path, os, http, https, child_process, __dirname, __filename, etc.) are unavailable by design. Use browser/DOM APIs only (window, document, fetch, localStorage, ...)", err)
 	}
 
 	scriptArgs := []any{}
@@ -188,53 +200,144 @@ func (s *ExecuteScriptTool) ExecuteScriptHandler(ctx context.Context, args map[s
 	return string(responseJSON), nil
 }
 
-// validateScriptSecurity performs basic security validation on the script
-func (s *ExecuteScriptTool) validateScriptSecurity(script string) error {
-	dangerousPatterns := []string{
-		// File system access
-		"require\\s*\\(\\s*['\"]fs['\"]",
-		"require\\s*\\(\\s*['\"]path['\"]",
-		"require\\s*\\(\\s*['\"]os['\"]",
-		// Network access
-		"require\\s*\\(\\s*['\"]http['\"]",
-		"require\\s*\\(\\s*['\"]https['\"]",
-		"require\\s*\\(\\s*['\"]net['\"]",
-		// Process execution
-		"require\\s*\\(\\s*['\"]child_process['\"]",
-		"exec\\s*\\(",
-		"spawn\\s*\\(",
-		// Eval and dynamic code execution
-		"eval\\s*\\(",
-		"function\\s*\\(",
-		"settimeout\\s*\\(",
-		"setinterval\\s*\\(",
-		// Global object access
-		"global\\.",
-		"process\\.",
-		"__dirname",
-		"__filename",
-		// Sensitive browser APIs that could be misused
-		"localStorage\\.clear",
-		"sessionStorage\\.clear",
-		"document\\.cookie\\s*=",
-		"window\\.location\\s*=",
-	}
+// dangerousScriptPattern pairs a regex with an LLM-actionable reason
+// explaining why the match is rejected. Patterns marked caseSensitive=true
+// are matched against the original script (not the lowercased form); the
+// rest are matched against strings.ToLower(script) for cheap normalization.
+type dangerousScriptPattern struct {
+	pattern       string
+	reason        string
+	caseSensitive bool
 
+	compiled *regexp.Regexp
+}
+
+// dangerousScriptPatterns enumerates patterns the validator rejects together
+// with the human-readable reason that is surfaced back to the caller. The
+// reasons are written for an LLM consumer: they name the offending construct,
+// explain why it cannot work in the browser execution context, and (where
+// useful) point at the correct browser/DOM alternative.
+//
+// Note: the legacy `function\s*\(` pattern was removed because it matched any
+// JavaScript function expression (including the IIFE this tool itself emits
+// in prepareScript and any user `(function () { ... })()`). The dynamic-code
+// hazard it tried to cover — the `Function` constructor — is now handled by
+// the case-sensitive `\bFunction\s*\(` pattern below.
+var dangerousScriptPatterns = []*dangerousScriptPattern{
+	{
+		pattern: `require\s*\(\s*['"]fs['"]`,
+		reason:  "uses Node.js `require('fs')` for filesystem access; the browser sandbox has no filesystem — there is no equivalent from page.evaluate()",
+	},
+	{
+		pattern: `require\s*\(\s*['"]path['"]`,
+		reason:  "uses Node.js `require('path')`; path manipulation must be done with plain string operations or URL APIs in the browser",
+	},
+	{
+		pattern: `require\s*\(\s*['"]os['"]`,
+		reason:  "uses Node.js `require('os')`; OS metadata is not exposed to the browser context — inspect `navigator.userAgent` / `navigator.platform` instead",
+	},
+	{
+		pattern: `require\s*\(\s*['"]http['"]`,
+		reason:  "uses Node.js `require('http')`; perform network requests with the browser `fetch()` or `XMLHttpRequest` APIs",
+	},
+	{
+		pattern: `require\s*\(\s*['"]https['"]`,
+		reason:  "uses Node.js `require('https')`; perform network requests with the browser `fetch()` or `XMLHttpRequest` APIs",
+	},
+	{
+		pattern: `require\s*\(\s*['"]net['"]`,
+		reason:  "uses Node.js `require('net')` for raw sockets; the browser sandbox cannot open raw TCP sockets",
+	},
+	{
+		pattern: `require\s*\(\s*['"]child_process['"]`,
+		reason:  "uses Node.js `require('child_process')`; the browser context cannot spawn subprocesses",
+	},
+	{
+		pattern: `\bexec\s*\(`,
+		reason:  "calls `exec(...)` (child_process); subprocess execution is not available in the browser context",
+	},
+	{
+		pattern: `\bspawn\s*\(`,
+		reason:  "calls `spawn(...)` (child_process); subprocess execution is not available in the browser context",
+	},
+	{
+		pattern: `\beval\s*\(`,
+		reason:  "calls `eval(...)`; dynamic code evaluation is blocked. Inline the logic directly instead",
+	},
+	{
+		// Case-sensitive: matches the `Function` constructor (`new Function(...)`
+		// or `Function(...)`) without flagging ordinary `function (...) { ... }`
+		// expressions or IIFEs like `(function () { ... })()`.
+		pattern:       `\bFunction\s*\(`,
+		reason:        "uses the `Function` constructor for dynamic code generation; this is blocked for the same reason as eval. Inline the logic directly instead. (Regular `function () { ... }` expressions and IIFEs are fine.)",
+		caseSensitive: true,
+	},
+	{
+		pattern: `\bsettimeout\s*\(`,
+		reason:  "schedules work with `setTimeout`; long-lived timers cannot outlive a single page.evaluate() call. If you need to wait, use the dedicated `wait_for_condition` tool",
+	},
+	{
+		pattern: `\bsetinterval\s*\(`,
+		reason:  "schedules work with `setInterval`; recurring timers cannot outlive a single page.evaluate() call. Use the dedicated `wait_for_condition` tool instead",
+	},
+	{
+		pattern: `\bglobal\.`,
+		reason:  "accesses the Node.js `global` object, which does not exist in the browser. Use `window` (or `globalThis`) for the page's global scope",
+	},
+	{
+		pattern: `\bprocess\.`,
+		reason:  "accesses Node.js `process.*` (cwd, env, argv, ...). The browser has no `process` global. For environment-like info use `navigator`, `location`, or ask the user to expose it via a dedicated tool",
+	},
+	{
+		pattern: `__dirname`,
+		reason:  "references the Node.js `__dirname` global; it does not exist in the browser. Use `location.href` / `document.baseURI` for the current page URL",
+	},
+	{
+		pattern: `__filename`,
+		reason:  "references the Node.js `__filename` global; it does not exist in the browser. Use `location.href` for the current page URL",
+	},
+	{
+		pattern: `localstorage\.clear`,
+		reason:  "calls `localStorage.clear()`; wiping the page's localStorage is blocked because it destroys session state. Remove individual keys with `localStorage.removeItem(key)` if needed",
+	},
+	{
+		pattern: `sessionstorage\.clear`,
+		reason:  "calls `sessionStorage.clear()`; wiping sessionStorage is blocked because it destroys session state. Remove individual keys with `sessionStorage.removeItem(key)` if needed",
+	},
+	{
+		pattern: `document\.cookie\s*=`,
+		reason:  "writes to `document.cookie`; cookie mutation from a script is blocked to protect the session. Use Playwright-level auth helpers / `handle_authentication` instead",
+	},
+	{
+		pattern: `window\.location\s*=`,
+		reason:  "assigns to `window.location` to force navigation; use the dedicated `navigate_to_url` tool so the agent can track the navigation",
+	},
+}
+
+func init() {
+	for _, p := range dangerousScriptPatterns {
+		p.compiled = regexp.MustCompile(p.pattern)
+	}
+}
+
+// validateScriptSecurity performs basic security validation on the script and
+// returns an LLM-actionable error describing exactly why the script was
+// rejected and how to express the intent in the browser context.
+func (s *ExecuteScriptTool) validateScriptSecurity(script string) error {
 	scriptLower := strings.ToLower(script)
 
-	for _, pattern := range dangerousPatterns {
-		matched, err := regexp.MatchString(pattern, scriptLower)
-		if err != nil {
-			s.logger.Warn("regex pattern validation failed", zap.String("pattern", pattern), zap.Error(err))
-			continue
+	for _, p := range dangerousScriptPatterns {
+		target := scriptLower
+		if p.caseSensitive {
+			target = script
 		}
-		if matched {
-			return fmt.Errorf("script contains potentially dangerous pattern: %s", pattern)
+		if p.compiled.MatchString(target) {
+			return fmt.Errorf("%s", p.reason)
 		}
 	}
 
 	if len(script) > 50000 {
-		return fmt.Errorf("script too large: %d characters (max 50000)", len(script))
+		return fmt.Errorf("script is too large: %d characters (max 50000). Split the work into smaller execute_script calls", len(script))
 	}
 
 	return nil

--- a/tools/execute_script_test.go
+++ b/tools/execute_script_test.go
@@ -173,9 +173,10 @@ func TestExecuteScriptTool_validateScriptSecurity(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		script      string
-		expectError bool
+		name          string
+		script        string
+		expectError   bool
+		errorContains string
 	}{
 		{
 			name:        "safe script should pass",
@@ -183,29 +184,78 @@ func TestExecuteScriptTool_validateScriptSecurity(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "script with file system access should fail",
-			script:      "require('fs').readFileSync('/etc/passwd');",
-			expectError: true,
+			name:        "function expression should pass (not a Function constructor)",
+			script:      "const add = function (a, b) { return a + b; }; return add(1, 2);",
+			expectError: false,
 		},
 		{
-			name:        "script with eval should fail",
-			script:      "eval('malicious code');",
-			expectError: true,
+			name:        "IIFE should pass (regression: legacy function\\s*\\( pattern)",
+			script:      "return (function () { return 42; })();",
+			expectError: false,
 		},
 		{
-			name:        "script with setTimeout should fail",
-			script:      "settimeout(() => { /* malicious */ }, 1000);",
-			expectError: true,
+			name:        "async IIFE should pass",
+			script:      "return (async function () { return await Promise.resolve(1); })();",
+			expectError: false,
 		},
 		{
-			name:        "script with global access should fail",
-			script:      "global.process.exit(1);",
-			expectError: true,
+			name:        "arrow function with setTimeout-like identifier in string should pass",
+			script:      "return 'documented setTimeout usage';",
+			expectError: false,
 		},
 		{
-			name:        "very long script should fail",
-			script:      string(make([]byte, 60000)),
-			expectError: true,
+			name:          "script with file system access should fail with actionable reason",
+			script:        "require('fs').readFileSync('/etc/passwd');",
+			expectError:   true,
+			errorContains: "browser sandbox has no filesystem",
+		},
+		{
+			name:          "script with eval should fail with actionable reason",
+			script:        "eval('malicious code');",
+			expectError:   true,
+			errorContains: "eval",
+		},
+		{
+			name:          "script with Function constructor should fail with actionable reason",
+			script:        "new Function('return 1')();",
+			expectError:   true,
+			errorContains: "Function` constructor",
+		},
+		{
+			name:          "script with setTimeout should fail with actionable reason",
+			script:        "settimeout(() => { /* malicious */ }, 1000);",
+			expectError:   true,
+			errorContains: "wait_for_condition",
+		},
+		{
+			name:          "script with global access should fail with actionable reason",
+			script:        "global.process.exit(1);",
+			expectError:   true,
+			errorContains: "Node.js `global`",
+		},
+		{
+			name:          "script with process.cwd should fail with actionable reason",
+			script:        "return process.cwd();",
+			expectError:   true,
+			errorContains: "`process`",
+		},
+		{
+			name:          "script with __dirname should fail with actionable reason",
+			script:        "return __dirname;",
+			expectError:   true,
+			errorContains: "__dirname",
+		},
+		{
+			name:          "script with window.location assignment should suggest navigate_to_url",
+			script:        "window.location = 'https://example.com';",
+			expectError:   true,
+			errorContains: "navigate_to_url",
+		},
+		{
+			name:          "very long script should fail",
+			script:        string(make([]byte, 60000)),
+			expectError:   true,
+			errorContains: "too large",
 		},
 	}
 
@@ -214,6 +264,11 @@ func TestExecuteScriptTool_validateScriptSecurity(t *testing.T) {
 			err := tool.validateScriptSecurity(tt.script)
 			if tt.expectError {
 				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+					assert.NotContains(t, err.Error(), `\s*\(`,
+						"error message must not leak raw regex syntax to the LLM")
+				}
 			} else {
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
## Summary

Fixes #79.

- The `execute_script` security validator no longer returns a raw regex pattern as the rejection reason. Each pattern is paired with a human-readable explanation that names the offending construct, explains why it cannot work in the browser context, and points at the correct browser/DOM alternative.
- Every rejection also restates the Playwright `page.evaluate()` execution context so the LLM stops retrying Node-only constructs like `require('fs')` / `process.cwd()`.
- Replaces the over-broad `function\s*\(` pattern (which matched any function expression, including the IIFE the tool itself emits) with the case-sensitive `\bFunction\s*\(` constructor-only pattern.
- Expands the tool description in both `execute_script.go` and `agent.yaml` so the browser-only constraint is visible on first invocation.
- Compiles patterns once at init time.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (new regression tests for IIFE, function expression, async IIFE, `Function` constructor, `process.cwd`, `__dirname`, `window.location`)
- [x] `task lint` → 0 issues

🤖 Generated with [Claude Code](https://claude.ai/code)