### PR TITLE
refactor(tools): Correctness and quality hardening pass

### DIFF
--- a/.adl-ignore
+++ b/.adl-ignore
@@ -17,6 +17,7 @@ tools/take_screenshot.go
 tools/execute_script.go
 tools/handle_authentication.go
 tools/wait_for_condition.go
+tools/args.go
 internal/playwright/playwright.go
 
 # Bare skill playbooks - edited by hand after initial scaffold

--- a/internal/playwright/playwright.go
+++ b/internal/playwright/playwright.go
@@ -2,6 +2,7 @@ package playwright
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -9,13 +10,14 @@ import (
 	"sync"
 	"time"
 
-	server "github.com/inference-gateway/adk/server"
-	types "github.com/inference-gateway/adk/types"
-	config "github.com/inference-gateway/browser-agent/config"
 	stealth "github.com/jonfriesen/playwright-go-stealth"
+	playwright "github.com/playwright-community/playwright-go"
 	zap "go.uber.org/zap"
 
-	"github.com/playwright-community/playwright-go"
+	server "github.com/inference-gateway/adk/server"
+	types "github.com/inference-gateway/adk/types"
+
+	config "github.com/inference-gateway/browser-agent/config"
 )
 
 // BrowserEngine represents the browser type
@@ -720,14 +722,16 @@ func (p *playwrightImpl) ExtractData(ctx context.Context, sessionID string, extr
 		}
 	}
 
-	switch format {
-	case "json":
-		return fmt.Sprintf("%+v", results), nil
-	case "csv":
-		return fmt.Sprintf("%+v", results), nil
-	default:
-		return fmt.Sprintf("%+v", results), nil
+	// The tool layer is responsible for converting this canonical JSON
+	// representation into the caller's requested output format (json, csv,
+	// text). Returning JSON unconditionally is what lets the tool drop a
+	// fragile Go-`%+v` map fallback parser.
+	_ = format
+	payload, err := json.Marshal(results)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal extracted data: %w", err)
 	}
+	return string(payload), nil
 }
 
 // TakeScreenshot captures a screenshot
@@ -833,6 +837,13 @@ func (p *playwrightImpl) WaitForCondition(ctx context.Context, sessionID, condit
 	case "timeout":
 		time.Sleep(timeout)
 		return nil
+
+	case "networkidle":
+		timeoutMs := float64(timeout.Milliseconds())
+		return session.Page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
+			State:   playwright.LoadStateNetworkidle,
+			Timeout: &timeoutMs,
+		})
 
 	default:
 		return fmt.Errorf("unsupported condition type: %s", condition)

--- a/tools/args.go
+++ b/tools/args.go
@@ -1,0 +1,141 @@
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+)
+
+// Shared defaults and bounds used across the manually-implemented tools.
+// Promoted from per-file magic numbers so behavior stays consistent.
+const (
+	defaultTimeoutMs   = 30000
+	minTimeoutMs       = 1
+	maxTimeoutMs       = 600000
+	defaultJPEGQuality = 80
+	minJPEGQuality     = 0
+	maxJPEGQuality     = 100
+	defaultClickCount  = 1
+	minClickCount      = 1
+	maxClickCount      = 10
+	maxScriptSize      = 50000
+
+	screenshotSelectorMaxRunes = 20
+)
+
+// requiredString returns args[key] as a non-empty string. Returns an error
+// if the key is absent, the value is not a string, or the string is empty.
+func requiredString(args map[string]any, key string) (string, error) {
+	raw, ok := args[key]
+	if !ok {
+		return "", fmt.Errorf("%s parameter is required", key)
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("%s must be a string, got %T", key, raw)
+	}
+	if s == "" {
+		return "", fmt.Errorf("%s must be a non-empty string", key)
+	}
+	return s, nil
+}
+
+// stringArg returns args[key] as a string, or defaultValue if absent or empty.
+// Returns an error if the key is present but the value is not a string.
+func stringArg(args map[string]any, key, defaultValue string) (string, error) {
+	raw, ok := args[key]
+	if !ok {
+		return defaultValue, nil
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("%s must be a string, got %T", key, raw)
+	}
+	if s == "" {
+		return defaultValue, nil
+	}
+	return s, nil
+}
+
+// boolArg returns args[key] as a bool, or defaultValue if absent.
+// Returns an error if the key is present but the value is not a bool.
+func boolArg(args map[string]any, key string, defaultValue bool) (bool, error) {
+	raw, ok := args[key]
+	if !ok {
+		return defaultValue, nil
+	}
+	b, ok := raw.(bool)
+	if !ok {
+		return false, fmt.Errorf("%s must be a boolean, got %T", key, raw)
+	}
+	return b, nil
+}
+
+// intArg returns args[key] as an int, or defaultValue if absent. Accepts
+// int, int64, and float64 (since JSON unmarshaling produces float64).
+// Returns an error if the value cannot be converted to a whole int.
+func intArg(args map[string]any, key string, defaultValue int) (int, error) {
+	raw, ok := args[key]
+	if !ok {
+		return defaultValue, nil
+	}
+	switch v := raw.(type) {
+	case int:
+		return v, nil
+	case int64:
+		return int(v), nil
+	case float64:
+		if v != float64(int(v)) {
+			return 0, fmt.Errorf("%s must be a whole integer, got %v", key, v)
+		}
+		return int(v), nil
+	default:
+		return 0, fmt.Errorf("%s must be an integer, got %T", key, raw)
+	}
+}
+
+// boundedIntArg returns args[key] as an int validated to be in
+// [minInclusive, maxInclusive]. Returns defaultValue if absent.
+func boundedIntArg(args map[string]any, key string, defaultValue, minInclusive, maxInclusive int) (int, error) {
+	v, err := intArg(args, key, defaultValue)
+	if err != nil {
+		return 0, err
+	}
+	if v < minInclusive || v > maxInclusive {
+		return 0, fmt.Errorf("%s must be between %d and %d, got %d", key, minInclusive, maxInclusive, v)
+	}
+	return v, nil
+}
+
+// sliceArg returns args[key] as []any. The second return value reports
+// whether the key was present (so callers can distinguish "missing" from
+// "present-but-empty"). Returns an error if the key is present but the
+// value is not an array.
+func sliceArg(args map[string]any, key string) ([]any, bool, error) {
+	raw, ok := args[key]
+	if !ok {
+		return nil, false, nil
+	}
+	s, ok := raw.([]any)
+	if !ok {
+		return nil, true, fmt.Errorf("%s must be an array, got %T", key, raw)
+	}
+	return s, true, nil
+}
+
+// marshalResponse encodes a tool response as JSON. Centralized so we get
+// consistent error messages and avoid scattering identical
+// json.Marshal+error-wrap boilerplate across every tool.
+func marshalResponse(response any) (string, error) {
+	b, err := json.Marshal(response)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal response: %w", err)
+	}
+	return string(b), nil
+}
+
+// oneOf reports whether candidate matches any of allowed. Centralized so
+// each tool's per-field validator can collapse to a single call.
+func oneOf(candidate string, allowed ...string) bool {
+	return slices.Contains(allowed, candidate)
+}

--- a/tools/click_element.go
+++ b/tools/click_element.go
@@ -7,10 +7,23 @@ import (
 	"strings"
 	"time"
 
-	server "github.com/inference-gateway/adk/server"
-	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
 	zap "go.uber.org/zap"
+
+	server "github.com/inference-gateway/adk/server"
+
+	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
 )
+
+// textSelectorPrefixes recognizes Playwright text-engine selectors.
+// Compiled once at package init instead of per call.
+var textSelectorPrefixes = regexp.MustCompile(`^(text=|:text\(|:has-text\(|:text-is\(|:text-matches\()`)
+
+var validButtons = []string{"left", "right", "middle"}
+
+func isQuotedString(s string) bool {
+	return (strings.HasPrefix(s, "'") && strings.HasSuffix(s, "'")) ||
+		(strings.HasPrefix(s, "\"") && strings.HasSuffix(s, "\""))
+}
 
 // ClickElementTool struct holds the tool with dependencies
 type ClickElementTool struct {
@@ -36,13 +49,13 @@ func NewClickElementTool(logger *zap.Logger, playwright playwright.BrowserAutoma
 					"type":        "string",
 				},
 				"click_count": map[string]any{
-					"default":     1,
+					"default":     defaultClickCount,
 					"description": "Number of times to click",
 					"type":        "integer",
 				},
 				"force": map[string]any{
 					"default":     false,
-					"description": "Force click even if element is not visible",
+					"description": "Force click even if element is not visible or actionable (skips the pre-click visibility wait)",
 					"type":        "boolean",
 				},
 				"selector": map[string]any{
@@ -50,7 +63,7 @@ func NewClickElementTool(logger *zap.Logger, playwright playwright.BrowserAutoma
 					"type":        "string",
 				},
 				"timeout": map[string]any{
-					"default":     30000,
+					"default":     defaultTimeoutMs,
 					"description": "Maximum time to wait for element in milliseconds",
 					"type":        "integer",
 				},
@@ -63,36 +76,32 @@ func NewClickElementTool(logger *zap.Logger, playwright playwright.BrowserAutoma
 
 // ClickElementHandler handles the click_element tool execution
 func (s *ClickElementTool) ClickElementHandler(ctx context.Context, args map[string]any) (string, error) {
-	selector, ok := args["selector"].(string)
-	if !ok || selector == "" {
-		return "", fmt.Errorf("selector parameter is required and must be a non-empty string")
+	selector, err := requiredString(args, "selector")
+	if err != nil {
+		return "", err
 	}
 
-	button := "left"
-	if b, ok := args["button"].(string); ok && b != "" {
-		if !s.isValidButton(b) {
-			return "", fmt.Errorf("invalid button value: %s. Must be one of: left, right, middle", b)
-		}
-		button = b
+	button, err := stringArg(args, "button", "left")
+	if err != nil {
+		return "", err
+	}
+	if !oneOf(button, validButtons...) {
+		return "", fmt.Errorf("invalid button value: %s. Must be one of: %v", button, validButtons)
 	}
 
-	clickCount := 1
-	if c, ok := args["click_count"].(int); ok && c > 0 {
-		clickCount = c
-	} else if cf, ok := args["click_count"].(float64); ok && cf > 0 {
-		clickCount = int(cf)
+	clickCount, err := boundedIntArg(args, "click_count", defaultClickCount, minClickCount, maxClickCount)
+	if err != nil {
+		return "", err
 	}
 
-	force := false
-	if f, ok := args["force"].(bool); ok {
-		force = f
+	force, err := boolArg(args, "force", false)
+	if err != nil {
+		return "", err
 	}
 
-	timeout := 30000
-	if t, ok := args["timeout"].(int); ok && t > 0 {
-		timeout = t
-	} else if tf, ok := args["timeout"].(float64); ok && tf > 0 {
-		timeout = int(tf)
+	timeout, err := boundedIntArg(args, "timeout", defaultTimeoutMs, minTimeoutMs, maxTimeoutMs)
+	if err != nil {
+		return "", err
 	}
 
 	s.logger.Info("clicking element",
@@ -114,24 +123,28 @@ func (s *ClickElementTool) ClickElementHandler(ctx context.Context, args map[str
 		zap.String("normalized", normalizedSelector),
 		zap.String("type", selectorType))
 
+	timeoutDuration := time.Duration(timeout) * time.Millisecond
 	options := map[string]any{
-		"timeout":     time.Duration(timeout) * time.Millisecond,
+		"timeout":     timeoutDuration,
 		"force":       force,
 		"click_count": clickCount,
 		"button":      button,
 	}
 
-	err = s.waitForElementActionable(ctx, session.ID, normalizedSelector, timeout)
-	if err != nil {
-		s.logger.Error("element not actionable",
-			zap.String("selector", normalizedSelector),
-			zap.String("sessionID", session.ID),
-			zap.Error(err))
-		return "", fmt.Errorf("element not actionable: %w", err)
+	// When force=true, skip the actionability wait — the caller explicitly
+	// asked to click without waiting for visibility (e.g. covered elements,
+	// pointer-events:none). The previous behaviour ignored the flag.
+	if !force {
+		if err := s.waitForElementActionable(ctx, session, normalizedSelector, timeout); err != nil {
+			s.logger.Error("element not actionable",
+				zap.String("selector", normalizedSelector),
+				zap.String("sessionID", session.ID),
+				zap.Error(err))
+			return "", fmt.Errorf("element not actionable: %w", err)
+		}
 	}
 
-	err = s.playwright.ClickElement(ctx, session.ID, normalizedSelector, options)
-	if err != nil {
+	if err := s.playwright.ClickElement(ctx, session.ID, normalizedSelector, options); err != nil {
 		s.logger.Error("click failed",
 			zap.String("selector", normalizedSelector),
 			zap.String("sessionID", session.ID),
@@ -143,7 +156,7 @@ func (s *ClickElementTool) ClickElementHandler(ctx context.Context, args map[str
 		zap.String("selector", normalizedSelector),
 		zap.String("sessionID", session.ID))
 
-	response := map[string]any{
+	return marshalResponse(map[string]any{
 		"success":       true,
 		"selector":      selector,
 		"button":        button,
@@ -153,47 +166,28 @@ func (s *ClickElementTool) ClickElementHandler(ctx context.Context, args map[str
 		"session_id":    session.ID,
 		"selector_type": selectorType,
 		"message":       "Element clicked successfully",
-	}
-
-	return fmt.Sprintf(`%+v`, response), nil
+	})
 }
 
-// isValidButton validates the button parameter
-func (s *ClickElementTool) isValidButton(button string) bool {
-	validButtons := []string{"left", "right", "middle"}
-	for _, valid := range validButtons {
-		if button == valid {
-			return true
-		}
-	}
-	return false
-}
-
-// normalizeSelector processes the selector to support CSS, XPath, and text-based strategies
+// normalizeSelector processes the selector to support CSS, XPath, and text-based strategies.
+// The text= classification matches Playwright's text engine PREFIXES exactly, not
+// substring "text=" which would false-positive on CSS like [data-text="x"].
 func (s *ClickElementTool) normalizeSelector(selector string) (string, string) {
 	selector = strings.TrimSpace(selector)
 
-	if strings.HasPrefix(selector, "/") || strings.HasPrefix(selector, "//") || strings.HasPrefix(selector, "xpath=") {
-		if strings.HasPrefix(selector, "xpath=") {
-			return selector[6:], "xpath"
-		}
+	if strings.HasPrefix(selector, "xpath=") {
+		return selector[6:], "xpath"
+	}
+	if strings.HasPrefix(selector, "/") || strings.HasPrefix(selector, "//") {
 		return selector, "xpath"
 	}
 
-	textRegex := regexp.MustCompile(`^(text=|:text\(|:has-text\(|:text-is\(|:text-matches\()`)
-	if textRegex.MatchString(selector) {
+	if textSelectorPrefixes.MatchString(selector) {
 		return selector, "text"
 	}
 
-	if strings.Contains(selector, "text=") ||
-		(strings.HasPrefix(selector, "'") && strings.HasSuffix(selector, "'")) ||
-		(strings.HasPrefix(selector, "\"") && strings.HasSuffix(selector, "\"")) {
-		if (strings.HasPrefix(selector, "'") && strings.HasSuffix(selector, "'")) ||
-			(strings.HasPrefix(selector, "\"") && strings.HasSuffix(selector, "\"")) {
-			text := selector[1 : len(selector)-1]
-			return fmt.Sprintf("text=%s", text), "text"
-		}
-		return selector, "text"
+	if isQuotedString(selector) {
+		return fmt.Sprintf("text=%s", selector[1:len(selector)-1]), "text"
 	}
 
 	if strings.HasPrefix(selector, "role=") || strings.Contains(selector, "[role=") {
@@ -207,28 +201,27 @@ func (s *ClickElementTool) normalizeSelector(selector string) (string, string) {
 	return selector, "css"
 }
 
-// waitForElementActionable waits for the element to be actionable before clicking
-func (s *ClickElementTool) waitForElementActionable(ctx context.Context, sessionID, selector string, timeoutMs int) error {
-	session, err := s.playwright.GetSession(sessionID)
-	if err != nil {
-		return fmt.Errorf("failed to get session: %w", err)
-	}
-
+// waitForElementActionable waits for the element to be actionable before clicking.
+// Called only when force=false; force=true skips this entirely.
+func (s *ClickElementTool) waitForElementActionable(ctx context.Context, session *playwright.BrowserSession, selector string, timeoutMs int) error {
 	timeoutDuration := time.Duration(timeoutMs) * time.Millisecond
 
-	err = s.playwright.WaitForCondition(ctx, sessionID, "selector", selector, "visible", timeoutDuration, "")
+	err := s.playwright.WaitForCondition(ctx, session.ID, "selector", selector, "visible", timeoutDuration, "")
 	if err != nil {
-		s.logger.Warn("element not visible, attempting force click if enabled",
+		s.logger.Warn("element not visible in main frame, checking iframes",
 			zap.String("selector", selector),
 			zap.Error(err))
-		return s.checkElementInIframes(ctx, session, selector)
+		return s.checkElementInIframes(session, selector)
 	}
 
 	return nil
 }
 
-// checkElementInIframes checks if the element exists within any iframes
-func (s *ClickElementTool) checkElementInIframes(ctx context.Context, session *playwright.BrowserSession, selector string) error {
+// checkElementInIframes reports whether the missing element might live in a
+// nested iframe (cross-frame click is not yet supported). It only inspects
+// the iframe count; the returned error tells the caller why the click cannot
+// proceed.
+func (s *ClickElementTool) checkElementInIframes(session *playwright.BrowserSession, selector string) error {
 	if session.Page == nil {
 		return fmt.Errorf("element not found: %s (page not available)", selector)
 	}
@@ -242,9 +235,9 @@ func (s *ClickElementTool) checkElementInIframes(ctx context.Context, session *p
 		return fmt.Errorf("element not found: %s", selector)
 	}
 
-	s.logger.Info("checking for element in iframes",
+	s.logger.Info("element absent from main frame, iframes detected",
 		zap.String("selector", selector),
 		zap.Int("iframe_count", iframeCount))
 
-	return fmt.Errorf("element not found in main frame, %d iframes detected but cross-frame clicking not yet implemented", iframeCount)
+	return fmt.Errorf("element not found in main frame, %d iframes detected but cross-frame clicking not yet implemented; pass force=true to click without the visibility wait", iframeCount)
 }

--- a/tools/click_element_test.go
+++ b/tools/click_element_test.go
@@ -2,24 +2,28 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
-	"github.com/inference-gateway/browser-agent/internal/playwright"
-	"github.com/inference-gateway/browser-agent/internal/playwright/mocks"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
+	zap "go.uber.org/zap"
+
+	assert "github.com/stretchr/testify/assert"
+
+	mocks "github.com/inference-gateway/browser-agent/internal/playwright/mocks"
+
+	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
 )
 
 func TestClickElementTool_ClickElementHandler(t *testing.T) {
 	logger := zap.NewNop()
 
 	tests := []struct {
-		name           string
-		args           map[string]any
-		setupMock      func(*mocks.FakeBrowserAutomation)
-		expectedError  bool
-		expectedResult string
+		name          string
+		args          map[string]any
+		setupMock     func(*mocks.FakeBrowserAutomation)
+		expectedError bool
+		errorContains string
 	}{
 		{
 			name: "successful basic click",
@@ -27,9 +31,7 @@ func TestClickElementTool_ClickElementHandler(t *testing.T) {
 				"selector": "#submit-button",
 			},
 			setupMock: func(m *mocks.FakeBrowserAutomation) {
-				session := &playwright.BrowserSession{
-					ID: "test-session",
-				}
+				session := &playwright.BrowserSession{ID: "test-session"}
 				m.GetOrCreateTaskSessionReturns(session, nil)
 				m.GetSessionReturns(session, nil)
 				m.WaitForConditionReturns(nil)
@@ -47,9 +49,7 @@ func TestClickElementTool_ClickElementHandler(t *testing.T) {
 				"timeout":     5000,
 			},
 			setupMock: func(m *mocks.FakeBrowserAutomation) {
-				session := &playwright.BrowserSession{
-					ID: "test-session",
-				}
+				session := &playwright.BrowserSession{ID: "test-session"}
 				m.GetOrCreateTaskSessionReturns(session, nil)
 				m.GetSessionReturns(session, nil)
 				m.WaitForConditionReturns(nil)
@@ -63,9 +63,7 @@ func TestClickElementTool_ClickElementHandler(t *testing.T) {
 				"selector": "//button[@id='submit']",
 			},
 			setupMock: func(m *mocks.FakeBrowserAutomation) {
-				session := &playwright.BrowserSession{
-					ID: "test-session",
-				}
+				session := &playwright.BrowserSession{ID: "test-session"}
 				m.GetOrCreateTaskSessionReturns(session, nil)
 				m.GetSessionReturns(session, nil)
 				m.WaitForConditionReturns(nil)
@@ -79,9 +77,7 @@ func TestClickElementTool_ClickElementHandler(t *testing.T) {
 				"selector": "'Click Me'",
 			},
 			setupMock: func(m *mocks.FakeBrowserAutomation) {
-				session := &playwright.BrowserSession{
-					ID: "test-session",
-				}
+				session := &playwright.BrowserSession{ID: "test-session"}
 				m.GetOrCreateTaskSessionReturns(session, nil)
 				m.GetSessionReturns(session, nil)
 				m.WaitForConditionReturns(nil)
@@ -96,6 +92,7 @@ func TestClickElementTool_ClickElementHandler(t *testing.T) {
 			},
 			setupMock:     func(m *mocks.FakeBrowserAutomation) {},
 			expectedError: true,
+			errorContains: "selector parameter is required",
 		},
 		{
 			name: "empty selector parameter",
@@ -104,6 +101,7 @@ func TestClickElementTool_ClickElementHandler(t *testing.T) {
 			},
 			setupMock:     func(m *mocks.FakeBrowserAutomation) {},
 			expectedError: true,
+			errorContains: "non-empty string",
 		},
 		{
 			name: "invalid button parameter",
@@ -113,6 +111,27 @@ func TestClickElementTool_ClickElementHandler(t *testing.T) {
 			},
 			setupMock:     func(m *mocks.FakeBrowserAutomation) {},
 			expectedError: true,
+			errorContains: "invalid button value",
+		},
+		{
+			name: "negative timeout rejected",
+			args: map[string]any{
+				"selector": "#button",
+				"timeout":  -1,
+			},
+			setupMock:     func(m *mocks.FakeBrowserAutomation) {},
+			expectedError: true,
+			errorContains: "timeout must be between",
+		},
+		{
+			name: "click_count must be positive",
+			args: map[string]any{
+				"selector":    "#button",
+				"click_count": 0,
+			},
+			setupMock:     func(m *mocks.FakeBrowserAutomation) {},
+			expectedError: true,
+			errorContains: "click_count must be between",
 		},
 		{
 			name: "browser launch failure",
@@ -130,9 +149,7 @@ func TestClickElementTool_ClickElementHandler(t *testing.T) {
 				"selector": "#nonexistent",
 			},
 			setupMock: func(m *mocks.FakeBrowserAutomation) {
-				session := &playwright.BrowserSession{
-					ID: "test-session",
-				}
+				session := &playwright.BrowserSession{ID: "test-session"}
 				m.GetOrCreateTaskSessionReturns(session, nil)
 				m.GetSessionReturns(session, nil)
 				m.WaitForConditionReturns(errors.New("element not found"))
@@ -145,9 +162,7 @@ func TestClickElementTool_ClickElementHandler(t *testing.T) {
 				"selector": "#button",
 			},
 			setupMock: func(m *mocks.FakeBrowserAutomation) {
-				session := &playwright.BrowserSession{
-					ID: "test-session",
-				}
+				session := &playwright.BrowserSession{ID: "test-session"}
 				m.GetOrCreateTaskSessionReturns(session, nil)
 				m.GetSessionReturns(session, nil)
 				m.WaitForConditionReturns(nil)
@@ -171,36 +186,43 @@ func TestClickElementTool_ClickElementHandler(t *testing.T) {
 
 			if tt.expectedError {
 				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
 				assert.Empty(t, result)
-			} else {
-				assert.NoError(t, err)
-				assert.Contains(t, result, "success:true")
+				return
 			}
+
+			assert.NoError(t, err)
+			var parsed map[string]any
+			assert.NoError(t, json.Unmarshal([]byte(result), &parsed), "response should be valid JSON")
+			assert.Equal(t, true, parsed["success"])
 		})
 	}
 }
 
-func TestClickElementTool_isValidButton(t *testing.T) {
-	tool := &ClickElementTool{}
+// TestClickElementTool_ForceSkipsActionabilityWait verifies that force=true
+// bypasses the visibility wait, which is the documented purpose of the flag.
+// Before the fix the flag was accepted but ignored.
+func TestClickElementTool_ForceSkipsActionabilityWait(t *testing.T) {
+	logger := zap.NewNop()
+	mockPlaywright := &mocks.FakeBrowserAutomation{}
+	session := &playwright.BrowserSession{ID: "test-session"}
+	mockPlaywright.GetOrCreateTaskSessionReturns(session, nil)
+	mockPlaywright.GetSessionReturns(session, nil)
+	mockPlaywright.ClickElementReturns(nil)
 
-	tests := []struct {
-		button   string
-		expected bool
-	}{
-		{"left", true},
-		{"right", true},
-		{"middle", true},
-		{"invalid", false},
-		{"", false},
-		{"LEFT", false},
-	}
+	tool := &ClickElementTool{logger: logger, playwright: mockPlaywright}
+	_, err := tool.ClickElementHandler(context.Background(), map[string]any{
+		"selector": "#hidden",
+		"force":    true,
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.button, func(t *testing.T) {
-			result := tool.isValidButton(tt.button)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, 0, mockPlaywright.WaitForConditionCallCount(),
+		"WaitForCondition should be skipped when force=true")
+	assert.Equal(t, 1, mockPlaywright.ClickElementCallCount(),
+		"ClickElement should still be invoked")
 }
 
 func TestClickElementTool_normalizeSelector(t *testing.T) {
@@ -276,6 +298,18 @@ func TestClickElementTool_normalizeSelector(t *testing.T) {
 			name:             "Complex CSS selector",
 			selector:         "div.container > button.primary:first-child",
 			expectedSelector: "div.container > button.primary:first-child",
+			expectedType:     "css",
+		},
+		{
+			name:             "CSS data-text attribute is not misclassified as text",
+			selector:         `[data-text="hello"]`,
+			expectedSelector: `[data-text="hello"]`,
+			expectedType:     "css",
+		},
+		{
+			name:             "CSS attribute selector with text in name stays CSS",
+			selector:         `input[name="search-text"]`,
+			expectedSelector: `input[name="search-text"]`,
 			expectedType:     "css",
 		},
 	}

--- a/tools/execute_script.go
+++ b/tools/execute_script.go
@@ -8,9 +8,11 @@ import (
 	"strings"
 	"time"
 
-	server "github.com/inference-gateway/adk/server"
-	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
 	zap "go.uber.org/zap"
+
+	server "github.com/inference-gateway/adk/server"
+
+	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
 )
 
 // ExecuteScriptTool struct holds the tool with dependencies
@@ -93,38 +95,40 @@ func NewExecuteScriptTool(logger *zap.Logger, playwright playwright.BrowserAutom
 func (s *ExecuteScriptTool) ExecuteScriptHandler(ctx context.Context, args map[string]any) (string, error) {
 	startTime := time.Now()
 
-	script, ok := args["script"].(string)
-	if !ok || script == "" {
-		return "", fmt.Errorf("script parameter is required and must be a non-empty string")
+	script, err := requiredString(args, "script")
+	if err != nil {
+		return "", err
 	}
 
 	if err := s.validateScriptSecurity(script); err != nil {
-		s.logger.Error("script security validation failed", zap.String("script", script), zap.Error(err))
+		s.logger.Error("script security validation failed",
+			zap.String("script_hash", s.calculateScriptHash(script)),
+			zap.Int("script_length", len(script)),
+			zap.Error(err))
 		return "", fmt.Errorf("execute_script rejected the script: %w. execute_script runs inside the browser via Playwright page.evaluate(); Node.js built-ins (require, process, fs, path, os, http, https, child_process, __dirname, __filename, etc.) are unavailable by design. Use browser/DOM APIs only (window, document, fetch, localStorage, ...)", err)
 	}
 
-	scriptArgs := []any{}
-	if argsVal, ok := args["args"]; ok {
-		if argsSlice, ok := argsVal.([]any); ok {
-			scriptArgs = argsSlice
-		}
+	scriptArgs, _, err := sliceArg(args, "args")
+	if err != nil {
+		return "", err
+	}
+	if scriptArgs == nil {
+		scriptArgs = []any{}
 	}
 
-	returnValue := true
-	if rv, ok := args["return_value"].(bool); ok {
-		returnValue = rv
+	returnValue, err := boolArg(args, "return_value", true)
+	if err != nil {
+		return "", err
 	}
 
-	timeout := 30000
-	if t, ok := args["timeout"].(int); ok && t > 0 {
-		timeout = t
-	} else if tf, ok := args["timeout"].(float64); ok && tf > 0 {
-		timeout = int(tf)
+	timeout, err := boundedIntArg(args, "timeout", defaultTimeoutMs, minTimeoutMs, maxTimeoutMs)
+	if err != nil {
+		return "", err
 	}
 
-	isAsync := false
-	if async, ok := args["async"].(bool); ok {
-		isAsync = async
+	isAsync, err := boolArg(args, "async", false)
+	if err != nil {
+		return "", err
 	}
 
 	processedScript, err := s.prepareScript(script, isAsync)
@@ -218,11 +222,18 @@ type dangerousScriptPattern struct {
 // explain why it cannot work in the browser execution context, and (where
 // useful) point at the correct browser/DOM alternative.
 //
-// Note: the legacy `function\s*\(` pattern was removed because it matched any
-// JavaScript function expression (including the IIFE this tool itself emits
-// in prepareScript and any user `(function () { ... })()`). The dynamic-code
-// hazard it tried to cover - the `Function` constructor - is now handled by
-// the case-sensitive `\bFunction\s*\(` pattern below.
+// Notes on regex shape:
+//   - The legacy `function\s*\(` pattern was removed because it matched any
+//     JavaScript function expression (including the IIFE this tool itself
+//     emits in prepareScript and any user `(function () { ... })()`). The
+//     dynamic-code hazard it tried to cover - the `Function` constructor -
+//     is now handled by the case-sensitive `(?:^|[^.\w])Function\s*\(`
+//     pattern below.
+//   - Identifier-prefixed patterns use `(?:^|[^.\w])` instead of `\b` so
+//     they don't match dotted property access (e.g. `myObj.process.env` or
+//     `arr.exec(re)`). RE2 has no lookbehind, so this prefix consumes one
+//     non-dot/non-word character before the identifier - that's fine for
+//     MatchString since we only care about presence, not position.
 var dangerousScriptPatterns = []*dangerousScriptPattern{
 	{
 		pattern: `require\s*\(\s*['"]fs['"]`,
@@ -253,52 +264,52 @@ var dangerousScriptPatterns = []*dangerousScriptPattern{
 		reason:  "uses Node.js `require('child_process')`; the browser context cannot spawn subprocesses",
 	},
 	{
-		pattern: `\bexec\s*\(`,
+		pattern: `(?:^|[^.\w])exec\s*\(`,
 		reason:  "calls `exec(...)` (child_process); subprocess execution is not available in the browser context",
 	},
 	{
-		pattern: `\bspawn\s*\(`,
+		pattern: `(?:^|[^.\w])spawn\s*\(`,
 		reason:  "calls `spawn(...)` (child_process); subprocess execution is not available in the browser context",
 	},
 	{
-		pattern: `\beval\s*\(`,
+		pattern: `(?:^|[^.\w])eval\s*\(`,
 		reason:  "calls `eval(...)`; dynamic code evaluation is blocked. Inline the logic directly instead",
 	},
 	{
-		pattern:       `\bFunction\s*\(`,
+		pattern:       `(?:^|[^.\w])Function\s*\(`,
 		reason:        "uses the `Function` constructor for dynamic code generation; this is blocked for the same reason as eval. Inline the logic directly instead. (Regular `function () { ... }` expressions and IIFEs are fine.)",
 		caseSensitive: true,
 	},
 	{
-		pattern: `\bsettimeout\s*\(`,
+		pattern: `(?:^|[^.\w])settimeout\s*\(`,
 		reason:  "schedules work with `setTimeout`; long-lived timers cannot outlive a single page.evaluate() call. If you need to wait, use the dedicated `wait_for_condition` tool",
 	},
 	{
-		pattern: `\bsetinterval\s*\(`,
+		pattern: `(?:^|[^.\w])setinterval\s*\(`,
 		reason:  "schedules work with `setInterval`; recurring timers cannot outlive a single page.evaluate() call. Use the dedicated `wait_for_condition` tool instead",
 	},
 	{
-		pattern: `\bglobal\.`,
+		pattern: `(?:^|[^.\w])global\.`,
 		reason:  "accesses the Node.js `global` object, which does not exist in the browser. Use `window` (or `globalThis`) for the page's global scope",
 	},
 	{
-		pattern: `\bprocess\.`,
+		pattern: `(?:^|[^.\w])process\.`,
 		reason:  "accesses Node.js `process.*` (cwd, env, argv, ...). The browser has no `process` global. For environment-like info use `navigator`, `location`, or ask the user to expose it via a dedicated tool",
 	},
 	{
-		pattern: `__dirname`,
+		pattern: `(?:^|[^.\w])__dirname`,
 		reason:  "references the Node.js `__dirname` global; it does not exist in the browser. Use `location.href` / `document.baseURI` for the current page URL",
 	},
 	{
-		pattern: `__filename`,
+		pattern: `(?:^|[^.\w])__filename`,
 		reason:  "references the Node.js `__filename` global; it does not exist in the browser. Use `location.href` for the current page URL",
 	},
 	{
-		pattern: `localstorage\.clear`,
+		pattern: `(?:^|[^.\w])localstorage\.clear`,
 		reason:  "calls `localStorage.clear()`; wiping the page's localStorage is blocked because it destroys session state. Remove individual keys with `localStorage.removeItem(key)` if needed",
 	},
 	{
-		pattern: `sessionstorage\.clear`,
+		pattern: `(?:^|[^.\w])sessionstorage\.clear`,
 		reason:  "calls `sessionStorage.clear()`; wiping sessionStorage is blocked because it destroys session state. Remove individual keys with `sessionStorage.removeItem(key)` if needed",
 	},
 	{
@@ -333,8 +344,8 @@ func (s *ExecuteScriptTool) validateScriptSecurity(script string) error {
 		}
 	}
 
-	if len(script) > 50000 {
-		return fmt.Errorf("script is too large: %d characters (max 50000). Split the work into smaller execute_script calls", len(script))
+	if len(script) > maxScriptSize {
+		return fmt.Errorf("script is too large: %d characters (max %d). Split the work into smaller execute_script calls", len(script), maxScriptSize)
 	}
 
 	return nil
@@ -384,7 +395,9 @@ func (s *ExecuteScriptTool) getResultType(result any) string {
 	switch result.(type) {
 	case bool:
 		return "boolean"
-	case int, int8, int16, int32, int64, float32, float64:
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
 		return "number"
 	case string:
 		return "string"

--- a/tools/execute_script_test.go
+++ b/tools/execute_script_test.go
@@ -7,10 +7,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/inference-gateway/browser-agent/internal/playwright"
-	"github.com/inference-gateway/browser-agent/internal/playwright/mocks"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
+	zap "go.uber.org/zap"
+
+	assert "github.com/stretchr/testify/assert"
+
+	mocks "github.com/inference-gateway/browser-agent/internal/playwright/mocks"
+
+	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
 )
 
 func TestExecuteScriptTool_ExecuteScriptHandler(t *testing.T) {
@@ -201,6 +204,51 @@ func TestExecuteScriptTool_validateScriptSecurity(t *testing.T) {
 		{
 			name:        "arrow function with setTimeout-like identifier in string should pass",
 			script:      "return 'documented setTimeout usage';",
+			expectError: false,
+		},
+		{
+			name:        "dotted property access process should pass",
+			script:      "return obj.process.value;",
+			expectError: false,
+		},
+		{
+			name:        "regex .exec on a user array should pass",
+			script:      "return /foo/.exec(text);",
+			expectError: false,
+		},
+		{
+			name:        "user array .exec should pass",
+			script:      "return arr.exec(/re/);",
+			expectError: false,
+		},
+		{
+			name:        "user object .global should pass",
+			script:      "return el.global.foo;",
+			expectError: false,
+		},
+		{
+			name:        "user object .spawn should pass",
+			script:      "return queue.spawn(worker);",
+			expectError: false,
+		},
+		{
+			name:        "user object .eval method should pass",
+			script:      "return calculator.eval(expression);",
+			expectError: false,
+		},
+		{
+			name:        "user object .setTimeout should pass",
+			script:      "return ticker.setTimeout(cb);",
+			expectError: false,
+		},
+		{
+			name:        "user identifier ending in __dirname should pass",
+			script:      "return obj.__dirname;",
+			expectError: false,
+		},
+		{
+			name:        "user property localStorage.clear on a non-global should pass",
+			script:      "return cache.localStorage.clear();",
 			expectError: false,
 		},
 		{

--- a/tools/extract_data.go
+++ b/tools/extract_data.go
@@ -6,13 +6,22 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
-	server "github.com/inference-gateway/adk/server"
-	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
 	zap "go.uber.org/zap"
+
+	server "github.com/inference-gateway/adk/server"
+
+	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
+)
+
+var (
+	validExtractFormats = []string{"json", "csv", "text"}
+
+	// Hoisted regexes — previously compiled per call inside cleanString.
+	whitespaceRun = regexp.MustCompile(`\s+`)
+	controlChars  = regexp.MustCompile(`[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]`)
 )
 
 // ExtractDataTool struct holds the tool with dependencies
@@ -35,8 +44,17 @@ func NewExtractDataTool(logger *zap.Logger, playwright playwright.BrowserAutomat
 			"properties": map[string]any{
 				"extractors": map[string]any{
 					"description": "List of data extractors to run",
-					"items":       map[string]any{"type": "object", "properties": map[string]any{"name": map[string]any{"type": "string", "description": "Name for the extracted data field"}, "selector": map[string]any{"type": "string", "description": "CSS selector or XPath to extract data from"}, "attribute": map[string]any{"type": "string", "description": "Attribute to extract (text, href, src, etc.)", "default": "text"}, "multiple": map[string]any{"type": "boolean", "description": "Extract all matching elements or just the first", "default": false}}, "required": []string{"name", "selector"}},
 					"type":        "array",
+					"items": map[string]any{
+						"required": []string{"name", "selector"},
+						"type":     "object",
+						"properties": map[string]any{
+							"name":      map[string]any{"type": "string", "description": "Name for the extracted data field"},
+							"selector":  map[string]any{"type": "string", "description": "CSS selector or XPath to extract data from"},
+							"attribute": map[string]any{"type": "string", "description": "Attribute to extract (text, href, src, etc.)", "default": "text"},
+							"multiple":  map[string]any{"type": "boolean", "description": "Extract all matching elements or just the first", "default": false},
+						},
+					},
 				},
 				"format": map[string]any{
 					"default":     "json",
@@ -50,24 +68,31 @@ func NewExtractDataTool(logger *zap.Logger, playwright playwright.BrowserAutomat
 	)
 }
 
-// ExtractDataHandler handles the extract_data tool execution
+// ExtractDataHandler handles the extract_data tool execution.
+//
+// The playwright service returns canonical JSON for the extracted map;
+// previously this tool carried a hand-rolled "Go %+v map" parser as a
+// fallback because the service emitted fmt.Sprintf("%+v", results). That
+// fallback is now gone.
 func (s *ExtractDataTool) ExtractDataHandler(ctx context.Context, args map[string]any) (string, error) {
-	extractors, ok := args["extractors"].([]any)
-	if !ok || len(extractors) == 0 {
-		s.logger.Error("extractors parameter is required and must be a non-empty array")
+	rawExtractors, present, err := sliceArg(args, "extractors")
+	if err != nil {
+		return "", err
+	}
+	if !present || len(rawExtractors) == 0 {
 		return "", fmt.Errorf("extractors parameter is required and must be a non-empty array")
 	}
 
-	format := "json"
-	if f, ok := args["format"].(string); ok && f != "" {
-		if !s.isValidFormat(f) {
-			return "", fmt.Errorf("invalid format: %s. Must be one of: json, csv, text", f)
-		}
-		format = f
+	format, err := stringArg(args, "format", "json")
+	if err != nil {
+		return "", err
+	}
+	if !oneOf(format, validExtractFormats...) {
+		return "", fmt.Errorf("invalid format: %s. Must be one of: %v", format, validExtractFormats)
 	}
 
 	s.logger.Info("extracting data from page",
-		zap.Int("extractors_count", len(extractors)),
+		zap.Int("extractors_count", len(rawExtractors)),
 		zap.String("format", format))
 
 	session, err := s.playwright.GetOrCreateTaskSession(ctx)
@@ -76,7 +101,7 @@ func (s *ExtractDataTool) ExtractDataHandler(ctx context.Context, args map[strin
 		return "", fmt.Errorf("failed to get browser session: %w", err)
 	}
 
-	playwrightExtractors, err := s.convertExtractors(extractors)
+	playwrightExtractors, err := s.convertExtractors(rawExtractors)
 	if err != nil {
 		s.logger.Error("failed to convert extractors", zap.Error(err))
 		return "", fmt.Errorf("failed to convert extractors: %w", err)
@@ -93,28 +118,35 @@ func (s *ExtractDataTool) ExtractDataHandler(ctx context.Context, args map[strin
 		return "", fmt.Errorf("data extraction failed: %w", err)
 	}
 
-	result, err := s.processExtractedData(rawResult, format, extractors)
+	parsed, err := s.parseRawResult(rawResult)
 	if err != nil {
-		s.logger.Error("failed to process extracted data", zap.Error(err))
-		return "", fmt.Errorf("failed to process extracted data: %w", err)
+		s.logger.Error("failed to parse extracted data", zap.Error(err))
+		return "", fmt.Errorf("failed to parse extracted data: %w", err)
 	}
 
-	s.logger.Info("data extraction completed successfully",
-		zap.String("sessionID", session.ID),
-		zap.String("format", format))
+	cleaned, _ := s.cleanAndNormalizeData(parsed).(map[string]any)
+	if cleaned == nil {
+		cleaned = parsed
+	}
 
-	return result, nil
+	switch format {
+	case "csv":
+		return s.formatAsCSV(cleaned)
+	case "text":
+		return s.formatAsText(cleaned), nil
+	default:
+		return s.formatAsJSON(cleaned, len(rawExtractors))
+	}
 }
 
-// isValidFormat validates the output format parameter
-func (s *ExtractDataTool) isValidFormat(format string) bool {
-	validFormats := []string{"json", "csv", "text"}
-	for _, valid := range validFormats {
-		if format == valid {
-			return true
-		}
+// parseRawResult parses the canonical JSON document returned by the
+// playwright service.
+func (s *ExtractDataTool) parseRawResult(rawResult string) (map[string]any, error) {
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(rawResult), &parsed); err != nil {
+		return nil, fmt.Errorf("playwright service returned non-JSON payload: %w", err)
 	}
-	return false
+	return parsed, nil
 }
 
 // convertExtractors converts extractors from any to the format expected by Playwright service
@@ -158,69 +190,37 @@ func (s *ExtractDataTool) convertExtractors(extractors []any) ([]map[string]any,
 	return converted, nil
 }
 
-// processExtractedData processes the raw extracted data and formats it according to the specified format
-func (s *ExtractDataTool) processExtractedData(rawResult, format string, originalExtractors []any) (string, error) {
-	switch format {
-	case "json":
-		return s.formatAsJSON(rawResult, originalExtractors)
-	case "csv":
-		return s.formatAsCSV(rawResult, originalExtractors)
-	case "text":
-		return s.formatAsText(rawResult, originalExtractors)
-	default:
-		return rawResult, nil
-	}
-}
-
-// formatAsJSON formats the extracted data as JSON with metadata
-func (s *ExtractDataTool) formatAsJSON(rawResult string, extractors []any) (string, error) {
-	parsedData, err := s.parseRawResult(rawResult)
-	if err != nil {
-		return "", err
-	}
-
-	result := map[string]any{
+// formatAsJSON wraps the extracted data in the canonical envelope with
+// metadata. Returns valid JSON.
+func (s *ExtractDataTool) formatAsJSON(data map[string]any, extractorCount int) (string, error) {
+	return marshalResponse(map[string]any{
 		"success":    true,
 		"format":     "json",
-		"extractors": len(extractors),
-		"data":       parsedData,
+		"extractors": extractorCount,
+		"data":       data,
 		"metadata": map[string]any{
 			"extraction_time": time.Now().Unix(),
-			"total_fields":    len(parsedData),
+			"total_fields":    len(data),
 		},
-	}
-
-	cleanedData := s.cleanAndNormalizeData(result["data"])
-	result["data"] = cleanedData
-
-	jsonBytes, err := json.MarshalIndent(result, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal JSON: %w", err)
-	}
-
-	return string(jsonBytes), nil
+	})
 }
 
-// formatAsCSV formats the extracted data as CSV
-func (s *ExtractDataTool) formatAsCSV(rawResult string, extractors []any) (string, error) {
-	parsedData, err := s.parseRawResult(rawResult)
-	if err != nil {
-		return "", err
-	}
+// formatAsCSV writes a header row of extractor names and as many data rows
+// as the largest array-valued field. Scalar fields appear only on the first
+// row.
+func (s *ExtractDataTool) formatAsCSV(data map[string]any) (string, error) {
+	var buf strings.Builder
+	writer := csv.NewWriter(&buf)
 
-	var csvBuilder strings.Builder
-	writer := csv.NewWriter(&csvBuilder)
-
-	headers := make([]string, 0, len(parsedData))
-	for key := range parsedData {
+	headers := make([]string, 0, len(data))
+	for key := range data {
 		headers = append(headers, key)
 	}
 	if err := writer.Write(headers); err != nil {
 		return "", fmt.Errorf("failed to write CSV header: %w", err)
 	}
 
-	rows := s.generateCSVRows(parsedData, headers)
-	for _, row := range rows {
+	for _, row := range generateCSVRows(data, headers) {
 		if err := writer.Write(row); err != nil {
 			return "", fmt.Errorf("failed to write CSV row: %w", err)
 		}
@@ -231,262 +231,67 @@ func (s *ExtractDataTool) formatAsCSV(rawResult string, extractors []any) (strin
 		return "", fmt.Errorf("CSV writing error: %w", err)
 	}
 
-	return csvBuilder.String(), nil
+	return buf.String(), nil
 }
 
-// formatAsText formats the extracted data as human-readable text
-func (s *ExtractDataTool) formatAsText(rawResult string, extractors []any) (string, error) {
-	parsedData, err := s.parseRawResult(rawResult)
-	if err != nil {
-		return "", err
-	}
+// formatAsText emits a human-readable rendering of the extracted data.
+func (s *ExtractDataTool) formatAsText(data map[string]any) string {
+	var buf strings.Builder
+	buf.WriteString("Extracted Data:\n")
+	buf.WriteString("==============\n\n")
 
-	var textBuilder strings.Builder
-	textBuilder.WriteString("Extracted Data:\n")
-	textBuilder.WriteString("==============\n\n")
-
-	for key, value := range parsedData {
-		fmt.Fprintf(&textBuilder, "%s: ", key)
+	for key, value := range data {
+		fmt.Fprintf(&buf, "%s: ", key)
 		switch v := value.(type) {
 		case []any:
-			textBuilder.WriteString("\n")
+			buf.WriteString("\n")
 			for i, item := range v {
-				fmt.Fprintf(&textBuilder, "  [%d] %v\n", i+1, item)
+				fmt.Fprintf(&buf, "  [%d] %v\n", i+1, item)
 			}
 		default:
-			fmt.Fprintf(&textBuilder, "%v\n", v)
+			fmt.Fprintf(&buf, "%v\n", v)
 		}
-		textBuilder.WriteString("\n")
+		buf.WriteString("\n")
 	}
 
-	return textBuilder.String(), nil
+	return buf.String()
 }
 
-// parseRawResult parses the raw result string from Playwright service
-func (s *ExtractDataTool) parseRawResult(rawResult string) (map[string]any, error) {
-
-	var parsedData map[string]any
-
-	if err := json.Unmarshal([]byte(rawResult), &parsedData); err == nil {
-		return parsedData, nil
-	}
-
-	if strings.HasPrefix(rawResult, "map[") && strings.HasSuffix(rawResult, "]") {
-		return s.parseGoMapFormat(rawResult)
-	}
-
-	return s.extractDataFromString(rawResult)
-}
-
-// parseGoMapFormat parses Go map format: map[key1:value1 key2:value2]
-func (s *ExtractDataTool) parseGoMapFormat(mapStr string) (map[string]any, error) {
-	data := make(map[string]any)
-
-	content := strings.TrimPrefix(mapStr, "map[")
-	content = strings.TrimSuffix(content, "]")
-
-	if content == "" {
-		return data, nil
-	}
-
-	parts := s.smartSplit(content)
-
-	for _, part := range parts {
-		if strings.Contains(part, ":") {
-			keyValue := strings.SplitN(part, ":", 2)
-			if len(keyValue) == 2 {
-				key := strings.TrimSpace(keyValue[0])
-				value := strings.TrimSpace(keyValue[1])
-
-				data[key] = s.parseValue(value)
-			}
-		}
-	}
-
-	return data, nil
-}
-
-// smartSplit splits the map content intelligently, handling quoted values and brackets
-func (s *ExtractDataTool) smartSplit(content string) []string {
-	var parts []string
-	var current strings.Builder
-	inBrackets := 0
-	inQuotes := false
-	foundKey := false
-
-	for i, char := range content {
-		switch char {
-		case '[':
-			inBrackets++
-			current.WriteRune(char)
-		case ']':
-			inBrackets--
-			current.WriteRune(char)
-		case '"', '\'':
-			inQuotes = !inQuotes
-			current.WriteRune(char)
-		case ':':
-			if inBrackets == 0 && !inQuotes && !foundKey {
-				foundKey = true
-				current.WriteRune(char)
-			} else {
-				current.WriteRune(char)
-			}
-		case ' ':
-			if inBrackets == 0 && !inQuotes && foundKey {
-				if s.isNextKeyStart(content, i) {
-					if current.Len() > 0 {
-						parts = append(parts, current.String())
-						current.Reset()
-						foundKey = false
-					}
-				} else {
-					current.WriteRune(char)
-				}
-			} else if inBrackets == 0 && !inQuotes && !foundKey {
-				if current.Len() > 0 {
-					parts = append(parts, current.String())
-					current.Reset()
-				}
-			} else {
-				current.WriteRune(char)
-			}
-		default:
-			current.WriteRune(char)
-		}
-	}
-
-	if current.Len() > 0 {
-		parts = append(parts, current.String())
-	}
-
-	return parts
-}
-
-// isNextKeyStart checks if the next non-space characters form a key (word followed by colon)
-func (s *ExtractDataTool) isNextKeyStart(content string, currentPos int) bool {
-	i := currentPos + 1
-	for i < len(content) && content[i] == ' ' {
-		i++
-	}
-
-	if i >= len(content) {
-		return false
-	}
-
-	wordStart := i
-	for i < len(content) && (content[i] != ' ' && content[i] != ':' && content[i] != '[' && content[i] != ']') {
-		i++
-	}
-
-	return i > wordStart && i < len(content) && content[i] == ':'
-}
-
-// parseValue attempts to parse a string value into appropriate Go type
-func (s *ExtractDataTool) parseValue(value string) any {
-	if strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]") {
-		arrayContent := strings.TrimPrefix(value, "[")
-		arrayContent = strings.TrimSuffix(arrayContent, "]")
-
-		if arrayContent == "" {
-			return []any{}
-		}
-
-		items := strings.Fields(arrayContent)
-		result := make([]any, len(items))
-		for i, item := range items {
-			result[i] = s.parseScalarValue(item)
-		}
-		return result
-	}
-
-	return s.parseScalarValue(value)
-}
-
-// parseScalarValue parses individual scalar values
-func (s *ExtractDataTool) parseScalarValue(value string) any {
-	if (strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"")) ||
-		(strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'")) {
-		return value[1 : len(value)-1]
-	}
-
-	if intVal, err := strconv.Atoi(value); err == nil {
-		return intVal
-	}
-
-	if floatVal, err := strconv.ParseFloat(value, 64); err == nil {
-		return floatVal
-	}
-
-	if boolVal, err := strconv.ParseBool(value); err == nil {
-		return boolVal
-	}
-
-	if value == "<nil>" || value == "null" {
-		return nil
-	}
-
-	return value
-}
-
-// extractDataFromString extracts data from string representation (fallback method)
-func (s *ExtractDataTool) extractDataFromString(result string) (map[string]any, error) {
-	data := make(map[string]any)
-
-	pattern := regexp.MustCompile(`(\w+):\s*([^\n]+)`)
-	matches := pattern.FindAllStringSubmatch(result, -1)
-
-	for _, match := range matches {
-		if len(match) >= 3 {
-			key := strings.TrimSpace(match[1])
-			value := strings.TrimSpace(match[2])
-			data[key] = value
-		}
-	}
-
-	return data, nil
-}
-
-// generateCSVRows generates CSV rows from parsed data, handling arrays appropriately
-func (s *ExtractDataTool) generateCSVRows(data map[string]any, headers []string) [][]string {
+// generateCSVRows generates CSV rows from parsed data. The number of rows
+// equals the longest array-valued field; scalar fields show only on row 0.
+func generateCSVRows(data map[string]any, headers []string) [][]string {
 	maxRows := 1
 	for _, value := range data {
-		if arr, ok := value.([]any); ok {
-			if len(arr) > maxRows {
-				maxRows = len(arr)
-			}
+		if arr, ok := value.([]any); ok && len(arr) > maxRows {
+			maxRows = len(arr)
 		}
 	}
 
 	rows := make([][]string, maxRows)
-	for i := 0; i < maxRows; i++ {
+	for i := range maxRows {
 		rows[i] = make([]string, len(headers))
 		for j, header := range headers {
-			value := data[header]
-			if arr, ok := value.([]any); ok {
-				if i < len(arr) {
-					rows[i][j] = fmt.Sprintf("%v", arr[i])
-				} else {
-					rows[i][j] = ""
+			switch v := data[header].(type) {
+			case []any:
+				if i < len(v) {
+					rows[i][j] = fmt.Sprintf("%v", v[i])
 				}
-			} else {
+			default:
 				if i == 0 {
-					rows[i][j] = fmt.Sprintf("%v", value)
-				} else {
-					rows[i][j] = ""
+					rows[i][j] = fmt.Sprintf("%v", v)
 				}
 			}
 		}
 	}
-
 	return rows
 }
 
-// cleanAndNormalizeData applies data cleaning and normalization
+// cleanAndNormalizeData walks the JSON tree and applies cleanString to
+// every string leaf.
 func (s *ExtractDataTool) cleanAndNormalizeData(data any) any {
 	switch v := data.(type) {
 	case map[string]any:
-		cleaned := make(map[string]any)
+		cleaned := make(map[string]any, len(v))
 		for key, value := range v {
 			cleaned[key] = s.cleanAndNormalizeData(value)
 		}
@@ -498,21 +303,17 @@ func (s *ExtractDataTool) cleanAndNormalizeData(data any) any {
 		}
 		return cleaned
 	case string:
-		return s.cleanString(v)
+		return cleanString(v)
 	default:
 		return v
 	}
 }
 
-// cleanString performs string cleaning and normalization
-func (s *ExtractDataTool) cleanString(text string) string {
+// cleanString collapses whitespace runs and strips control characters.
+// Regexes are package-level so they compile once.
+func cleanString(text string) string {
 	cleaned := strings.TrimSpace(text)
-
-	spaceRegex := regexp.MustCompile(`\s+`)
-	cleaned = spaceRegex.ReplaceAllString(cleaned, " ")
-
-	controlRegex := regexp.MustCompile(`[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]`)
-	cleaned = controlRegex.ReplaceAllString(cleaned, "")
-
+	cleaned = whitespaceRun.ReplaceAllString(cleaned, " ")
+	cleaned = controlChars.ReplaceAllString(cleaned, "")
 	return cleaned
 }

--- a/tools/extract_data_test.go
+++ b/tools/extract_data_test.go
@@ -2,26 +2,25 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
-	"github.com/inference-gateway/browser-agent/internal/playwright"
-	"github.com/inference-gateway/browser-agent/internal/playwright/mocks"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
+	zap "go.uber.org/zap"
+
+	assert "github.com/stretchr/testify/assert"
+
+	mocks "github.com/inference-gateway/browser-agent/internal/playwright/mocks"
+
+	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
 )
 
 func TestExtractDataHandler(t *testing.T) {
 	logger := zap.NewNop()
-	mockPlaywright := &mocks.FakeBrowserAutomation{}
-	tool := &ExtractDataTool{
-		logger:     logger,
-		playwright: mockPlaywright,
-	}
 
 	tests := []struct {
 		name        string
 		args        map[string]any
-		mockSetup   func()
+		mockSetup   func(*mocks.FakeBrowserAutomation)
 		expectedErr bool
 		contains    string
 	}{
@@ -36,9 +35,9 @@ func TestExtractDataHandler(t *testing.T) {
 				},
 				"format": "json",
 			},
-			mockSetup: func() {
-				mockPlaywright.GetOrCreateTaskSessionReturns(&playwright.BrowserSession{ID: "test-session"}, nil)
-				mockPlaywright.ExtractDataReturns(`map[title:Test Title]`, nil)
+			mockSetup: func(m *mocks.FakeBrowserAutomation) {
+				m.GetOrCreateTaskSessionReturns(&playwright.BrowserSession{ID: "test-session"}, nil)
+				m.ExtractDataReturns(`{"title":"Test Title"}`, nil)
 			},
 			expectedErr: false,
 			contains:    "Test Title",
@@ -61,9 +60,9 @@ func TestExtractDataHandler(t *testing.T) {
 				},
 				"format": "json",
 			},
-			mockSetup: func() {
-				mockPlaywright.GetOrCreateTaskSessionReturns(&playwright.BrowserSession{ID: "test-session"}, nil)
-				mockPlaywright.ExtractDataReturns(`map[title:Test Title links:[/page1 /page2]]`, nil)
+			mockSetup: func(m *mocks.FakeBrowserAutomation) {
+				m.GetOrCreateTaskSessionReturns(&playwright.BrowserSession{ID: "test-session"}, nil)
+				m.ExtractDataReturns(`{"title":"Test Title","links":["/page1","/page2"]}`, nil)
 			},
 			expectedErr: false,
 			contains:    "Test Title",
@@ -79,9 +78,9 @@ func TestExtractDataHandler(t *testing.T) {
 				},
 				"format": "csv",
 			},
-			mockSetup: func() {
-				mockPlaywright.GetOrCreateTaskSessionReturns(&playwright.BrowserSession{ID: "test-session"}, nil)
-				mockPlaywright.ExtractDataReturns(`map[title:Test Title]`, nil)
+			mockSetup: func(m *mocks.FakeBrowserAutomation) {
+				m.GetOrCreateTaskSessionReturns(&playwright.BrowserSession{ID: "test-session"}, nil)
+				m.ExtractDataReturns(`{"title":"Test Title"}`, nil)
 			},
 			expectedErr: false,
 			contains:    "title",
@@ -97,9 +96,9 @@ func TestExtractDataHandler(t *testing.T) {
 				},
 				"format": "text",
 			},
-			mockSetup: func() {
-				mockPlaywright.GetOrCreateTaskSessionReturns(&playwright.BrowserSession{ID: "test-session"}, nil)
-				mockPlaywright.ExtractDataReturns(`map[title:Test Title]`, nil)
+			mockSetup: func(m *mocks.FakeBrowserAutomation) {
+				m.GetOrCreateTaskSessionReturns(&playwright.BrowserSession{ID: "test-session"}, nil)
+				m.ExtractDataReturns(`{"title":"Test Title"}`, nil)
 			},
 			expectedErr: false,
 			contains:    "Extracted Data",
@@ -109,7 +108,7 @@ func TestExtractDataHandler(t *testing.T) {
 			args: map[string]any{
 				"format": "json",
 			},
-			mockSetup:   func() {},
+			mockSetup:   func(m *mocks.FakeBrowserAutomation) {},
 			expectedErr: true,
 			contains:    "extractors parameter is required",
 		},
@@ -119,7 +118,7 @@ func TestExtractDataHandler(t *testing.T) {
 				"extractors": []any{},
 				"format":     "json",
 			},
-			mockSetup:   func() {},
+			mockSetup:   func(m *mocks.FakeBrowserAutomation) {},
 			expectedErr: true,
 			contains:    "extractors parameter is required",
 		},
@@ -134,7 +133,7 @@ func TestExtractDataHandler(t *testing.T) {
 				},
 				"format": "xml",
 			},
-			mockSetup:   func() {},
+			mockSetup:   func(m *mocks.FakeBrowserAutomation) {},
 			expectedErr: true,
 			contains:    "invalid format",
 		},
@@ -148,7 +147,7 @@ func TestExtractDataHandler(t *testing.T) {
 				},
 				"format": "json",
 			},
-			mockSetup:   func() {},
+			mockSetup:   func(m *mocks.FakeBrowserAutomation) {},
 			expectedErr: true,
 			contains:    "must have a non-empty 'name' field",
 		},
@@ -162,7 +161,7 @@ func TestExtractDataHandler(t *testing.T) {
 				},
 				"format": "json",
 			},
-			mockSetup:   func() {},
+			mockSetup:   func(m *mocks.FakeBrowserAutomation) {},
 			expectedErr: true,
 			contains:    "must have a non-empty 'selector' field",
 		},
@@ -170,22 +169,47 @@ func TestExtractDataHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockPlaywright = &mocks.FakeBrowserAutomation{}
-			tool.playwright = mockPlaywright
+			mockPlaywright := &mocks.FakeBrowserAutomation{}
+			tt.mockSetup(mockPlaywright)
 
-			tt.mockSetup()
-
+			tool := &ExtractDataTool{logger: logger, playwright: mockPlaywright}
 			result, err := tool.ExtractDataHandler(context.Background(), tt.args)
 
 			if tt.expectedErr {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.contains)
-			} else {
-				assert.NoError(t, err)
-				assert.Contains(t, result, tt.contains)
+				return
 			}
+
+			assert.NoError(t, err)
+			assert.Contains(t, result, tt.contains)
 		})
 	}
+}
+
+// TestExtractDataHandler_JSONFormat_ProducesValidJSON checks that the
+// json output is itself parseable — guards against future regressions
+// to the broken `%+v` envelope.
+func TestExtractDataHandler_JSONFormat_ProducesValidJSON(t *testing.T) {
+	mockPlaywright := &mocks.FakeBrowserAutomation{}
+	mockPlaywright.GetOrCreateTaskSessionReturns(&playwright.BrowserSession{ID: "test-session"}, nil)
+	mockPlaywright.ExtractDataReturns(`{"title":"  Spaced  Out  ","count":42}`, nil)
+
+	tool := &ExtractDataTool{logger: zap.NewNop(), playwright: mockPlaywright}
+	result, err := tool.ExtractDataHandler(context.Background(), map[string]any{
+		"extractors": []any{map[string]any{"name": "title", "selector": "h1"}},
+		"format":     "json",
+	})
+	assert.NoError(t, err)
+
+	var parsed map[string]any
+	assert.NoError(t, json.Unmarshal([]byte(result), &parsed))
+	assert.Equal(t, true, parsed["success"])
+	assert.Equal(t, "json", parsed["format"])
+
+	data, _ := parsed["data"].(map[string]any)
+	assert.Equal(t, "Spaced Out", data["title"], "whitespace runs should collapse via cleanString")
+	assert.Equal(t, float64(42), data["count"])
 }
 
 func TestConvertExtractors(t *testing.T) {
@@ -259,56 +283,7 @@ func TestConvertExtractors(t *testing.T) {
 	}
 }
 
-func TestParseGoMapFormat(t *testing.T) {
-	tool := &ExtractDataTool{}
-
-	tests := []struct {
-		name     string
-		input    string
-		expected map[string]any
-	}{
-		{
-			name:  "simple map",
-			input: "map[title:Test Title count:42]",
-			expected: map[string]any{
-				"title": "Test Title",
-				"count": 42,
-			},
-		},
-		{
-			name:  "map with array",
-			input: "map[links:[/page1 /page2 /page3]]",
-			expected: map[string]any{
-				"links": []any{"/page1", "/page2", "/page3"},
-			},
-		},
-		{
-			name:     "empty map",
-			input:    "map[]",
-			expected: map[string]any{},
-		},
-		{
-			name:  "map with boolean and nil",
-			input: "map[active:true missing:<nil>]",
-			expected: map[string]any{
-				"active":  true,
-				"missing": nil,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := tool.parseGoMapFormat(tt.input)
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestCleanString(t *testing.T) {
-	tool := &ExtractDataTool{}
-
 	tests := []struct {
 		name     string
 		input    string
@@ -338,31 +313,7 @@ func TestCleanString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tool.cleanString(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestIsValidFormat(t *testing.T) {
-	tool := &ExtractDataTool{}
-
-	tests := []struct {
-		format   string
-		expected bool
-	}{
-		{"json", true},
-		{"csv", true},
-		{"text", true},
-		{"xml", false},
-		{"", false},
-		{"JSON", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.format, func(t *testing.T) {
-			result := tool.isValidFormat(tt.format)
-			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, tt.expected, cleanString(tt.input))
 		})
 	}
 }

--- a/tools/fill_form.go
+++ b/tools/fill_form.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"fmt"
 
-	server "github.com/inference-gateway/adk/server"
-	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
 	zap "go.uber.org/zap"
+
+	server "github.com/inference-gateway/adk/server"
+
+	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
 )
+
+var validFieldTypes = []string{"text", "textarea", "password", "select", "checkbox", "radio", "file"}
 
 // FillFormTool struct holds the tool with dependencies
 type FillFormTool struct {
@@ -71,75 +75,38 @@ func NewFillFormTool(logger *zap.Logger, playwright playwright.BrowserAutomation
 	)
 }
 
-// FillFormHandler handles the fill_form tool execution
+// FillFormHandler handles the fill_form tool execution.
+//
+// Unlike the previous implementation, the underlying playwright service is
+// called ONCE with the full field batch (and the submit flag), rather than
+// per-field. The per-field loop was N round-trips and a separate submit
+// click with a mismatched timeout type.
 func (s *FillFormTool) FillFormHandler(ctx context.Context, args map[string]any) (string, error) {
-	fieldsRaw, ok := args["fields"]
-	if !ok {
+	rawFields, present, err := sliceArg(args, "fields")
+	if err != nil {
+		return "", err
+	}
+	if !present {
 		return "", fmt.Errorf("fields parameter is required")
 	}
-
-	fieldsSlice, ok := fieldsRaw.([]any)
-	if !ok {
-		return "", fmt.Errorf("fields must be an array")
-	}
-
-	if len(fieldsSlice) == 0 {
+	if len(rawFields) == 0 {
 		return "", fmt.Errorf("at least one field is required")
 	}
 
-	fields := make([]map[string]any, 0, len(fieldsSlice))
-	for i, fieldRaw := range fieldsSlice {
-		fieldMap, ok := fieldRaw.(map[string]any)
-		if !ok {
-			return "", fmt.Errorf("field %d must be an object", i)
-		}
-
-		selector, hasSelector := fieldMap["selector"].(string)
-		if !hasSelector || selector == "" {
-			return "", fmt.Errorf("field %d: selector is required and must be a non-empty string", i)
-		}
-
-		_, hasValue := fieldMap["value"].(string)
-		if !hasValue {
-			return "", fmt.Errorf("field %d: value is required", i)
-		}
-
-		if _, hasType := fieldMap["type"]; !hasType {
-			fieldMap["type"] = "text"
-		}
-
-		fieldType := fieldMap["type"].(string)
-		validTypes := []string{"text", "textarea", "password", "select", "checkbox", "radio", "file"}
-		isValidType := false
-		for _, vt := range validTypes {
-			if fieldType == vt {
-				isValidType = true
-				break
-			}
-		}
-		if !isValidType {
-			return "", fmt.Errorf("field %d: invalid type '%s'. Must be one of: %v", i, fieldType, validTypes)
-		}
-
-		fields = append(fields, fieldMap)
+	fields, err := s.validateAndNormalizeFields(rawFields)
+	if err != nil {
+		return "", err
 	}
 
-	submit := false
-	if submitRaw, ok := args["submit"]; ok {
-		if submitBool, ok := submitRaw.(bool); ok {
-			submit = submitBool
-		}
+	submit, err := boolArg(args, "submit", false)
+	if err != nil {
+		return "", err
 	}
 
 	submitSelector := ""
 	if submit {
-		if submitSelectorRaw, ok := args["submit_selector"]; ok {
-			if ss, ok := submitSelectorRaw.(string); ok && ss != "" {
-				submitSelector = ss
-			} else {
-				return "", fmt.Errorf("submit_selector is required when submit is true")
-			}
-		} else {
+		submitSelector, err = requiredString(args, "submit_selector")
+		if err != nil {
 			return "", fmt.Errorf("submit_selector is required when submit is true")
 		}
 	}
@@ -155,106 +122,59 @@ func (s *FillFormTool) FillFormHandler(ctx context.Context, args map[string]any)
 		return "", fmt.Errorf("failed to get browser session: %w", err)
 	}
 
-	fieldResults := make([]map[string]any, 0, len(fields))
-
-	for i, field := range fields {
-		fieldResult := map[string]any{
-			"field_index": i,
-			"selector":    field["selector"],
-			"type":        field["type"],
-			"success":     false,
-		}
-
-		selector := field["selector"].(string)
-		fieldType := field["type"].(string)
-
-		s.logger.Info("processing field",
-			zap.Int("index", i),
-			zap.String("selector", selector),
-			zap.String("type", fieldType))
-
-		err := s.fillSingleField(ctx, session.ID, field)
-		if err != nil {
-			s.logger.Error("failed to fill field",
-				zap.Int("index", i),
-				zap.String("selector", selector),
-				zap.Error(err))
-			fieldResult["error"] = err.Error()
-			fieldResults = append(fieldResults, fieldResult)
-
-			errorResponse := map[string]any{
-				"success":      false,
-				"session_id":   session.ID,
-				"fields_count": len(fields),
-				"fields":       fieldResults,
-				"error":        fmt.Sprintf("Failed to fill field %d (%s): %v", i, selector, err),
-			}
-
-			return fmt.Sprintf(`%+v`, errorResponse), fmt.Errorf("failed to fill field %d (%s): %w", i, selector, err)
-		}
-
-		fieldResult["success"] = true
-		fieldResult["message"] = "Field filled successfully"
-		fieldResults = append(fieldResults, fieldResult)
-
-		s.logger.Info("field filled successfully",
-			zap.Int("index", i),
-			zap.String("selector", selector))
+	if err := s.playwright.FillForm(ctx, session.ID, fields, submit, submitSelector); err != nil {
+		s.logger.Error("fill_form failed",
+			zap.String("sessionID", session.ID),
+			zap.Error(err))
+		return "", fmt.Errorf("fill_form failed: %w", err)
 	}
 
-	var submitResult map[string]any
+	message := fmt.Sprintf("Successfully filled %d fields", len(fields))
 	if submit {
-		s.logger.Info("submitting form", zap.String("submit_selector", submitSelector))
-
-		err = s.playwright.ClickElement(ctx, session.ID, submitSelector, map[string]any{
-			"timeout": 30000,
-		})
-
-		submitResult = map[string]any{
-			"submit_selector": submitSelector,
-			"success":         err == nil,
-		}
-
-		if err != nil {
-			s.logger.Error("failed to submit form", zap.String("submit_selector", submitSelector), zap.Error(err))
-			submitResult["error"] = err.Error()
-			return "", fmt.Errorf("failed to submit form: %w", err)
-		} else {
-			s.logger.Info("form submitted successfully", zap.String("submit_selector", submitSelector))
-			submitResult["message"] = "Form submitted successfully"
-		}
+		message = fmt.Sprintf("Successfully filled %d fields and submitted form", len(fields))
 	}
 
-	response := map[string]any{
-		"success":      true,
-		"session_id":   session.ID,
-		"fields_count": len(fields),
-		"fields":       fieldResults,
-		"message":      fmt.Sprintf("Successfully filled %d fields", len(fields)),
-	}
+	s.logger.Info("fill_form completed", zap.String("sessionID", session.ID))
 
-	if submit {
-		response["submit"] = submitResult
-		if submitResult["success"].(bool) {
-			response["message"] = fmt.Sprintf("Successfully filled %d fields and submitted form", len(fields))
-		}
-	}
-
-	return fmt.Sprintf(`%+v`, response), nil
+	return marshalResponse(map[string]any{
+		"success":         true,
+		"session_id":      session.ID,
+		"fields_count":    len(fields),
+		"submit":          submit,
+		"submit_selector": submitSelector,
+		"message":         message,
+	})
 }
 
-// fillSingleField handles filling a single form field with enhanced type support
-func (s *FillFormTool) fillSingleField(ctx context.Context, sessionID string, field map[string]any) error {
-	fields := []map[string]any{field}
+// validateAndNormalizeFields converts the raw []any into validated
+// []map[string]any, defaulting field type to "text" if absent.
+func (s *FillFormTool) validateAndNormalizeFields(rawFields []any) ([]map[string]any, error) {
+	fields := make([]map[string]any, 0, len(rawFields))
+	for i, raw := range rawFields {
+		field, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("field %d must be an object", i)
+		}
 
-	selector := field["selector"].(string)
-	value := field["value"].(string)
-	fieldType := field["type"].(string)
+		selector, hasSelector := field["selector"].(string)
+		if !hasSelector || selector == "" {
+			return nil, fmt.Errorf("field %d: selector is required and must be a non-empty string", i)
+		}
 
-	s.logger.Debug("delegating field filling to playwright service",
-		zap.String("selector", selector),
-		zap.String("type", fieldType),
-		zap.String("value", value))
+		if _, hasValue := field["value"].(string); !hasValue {
+			return nil, fmt.Errorf("field %d: value is required and must be a string", i)
+		}
 
-	return s.playwright.FillForm(ctx, sessionID, fields, false, "")
+		fieldType, _ := field["type"].(string)
+		if fieldType == "" {
+			fieldType = "text"
+			field["type"] = fieldType
+		}
+		if !oneOf(fieldType, validFieldTypes...) {
+			return nil, fmt.Errorf("field %d: invalid type '%s'. Must be one of: %v", i, fieldType, validFieldTypes)
+		}
+
+		fields = append(fields, field)
+	}
+	return fields, nil
 }

--- a/tools/fill_form_test.go
+++ b/tools/fill_form_test.go
@@ -2,13 +2,15 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
+	assert "github.com/stretchr/testify/assert"
+	zap "go.uber.org/zap"
+
+	mocks "github.com/inference-gateway/browser-agent/internal/playwright/mocks"
 
 	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
-	mocks "github.com/inference-gateway/browser-agent/internal/playwright/mocks"
 )
 
 func TestFillFormTool_FillFormHandler_ValidationTests(t *testing.T) {
@@ -121,21 +123,6 @@ func TestFillFormTool_FillFormHandler_ValidationTests(t *testing.T) {
 }
 
 func TestFillFormTool_FillFormHandler_SuccessTests(t *testing.T) {
-	logger := zap.NewNop()
-	mockPlaywright := &mocks.FakeBrowserAutomation{}
-
-	tool := &FillFormTool{
-		logger:     logger,
-		playwright: mockPlaywright,
-	}
-
-	session := &playwright.BrowserSession{ID: "test-session"}
-	mockPlaywright.GetOrCreateTaskSessionReturns(session, nil)
-	mockPlaywright.GetSessionReturns(session, nil)
-	mockPlaywright.FillFormReturns(nil)
-	mockPlaywright.FillFormReturns(nil)
-	mockPlaywright.ClickElementReturns(nil)
-
 	tests := []struct {
 		name string
 		args map[string]any
@@ -192,13 +179,60 @@ func TestFillFormTool_FillFormHandler_SuccessTests(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			logger := zap.NewNop()
+			mockPlaywright := &mocks.FakeBrowserAutomation{}
+			session := &playwright.BrowserSession{ID: "test-session"}
+			mockPlaywright.GetOrCreateTaskSessionReturns(session, nil)
+			mockPlaywright.GetSessionReturns(session, nil)
+			mockPlaywright.FillFormReturns(nil)
+
+			tool := &FillFormTool{logger: logger, playwright: mockPlaywright}
 			result, err := tool.FillFormHandler(context.Background(), tt.args)
 
 			assert.NoError(t, err)
 			assert.NotEmpty(t, result)
-			assert.Contains(t, result, "success")
+
+			var parsed map[string]any
+			assert.NoError(t, json.Unmarshal([]byte(result), &parsed), "response should be valid JSON")
+			assert.Equal(t, true, parsed["success"])
 		})
 	}
+}
+
+// TestFillFormTool_FillFormHandler_SingleBatchCall confirms the refactor:
+// previously the tool re-called FillForm once per field and additionally
+// called ClickElement to submit. After the fix, the playwright service
+// receives one batched call regardless of field count.
+func TestFillFormTool_FillFormHandler_SingleBatchCall(t *testing.T) {
+	logger := zap.NewNop()
+	mockPlaywright := &mocks.FakeBrowserAutomation{}
+	session := &playwright.BrowserSession{ID: "test-session"}
+	mockPlaywright.GetOrCreateTaskSessionReturns(session, nil)
+	mockPlaywright.GetSessionReturns(session, nil)
+	mockPlaywright.FillFormReturns(nil)
+
+	tool := &FillFormTool{logger: logger, playwright: mockPlaywright}
+
+	_, err := tool.FillFormHandler(context.Background(), map[string]any{
+		"fields": []any{
+			map[string]any{"selector": "#a", "value": "1"},
+			map[string]any{"selector": "#b", "value": "2"},
+			map[string]any{"selector": "#c", "value": "3"},
+		},
+		"submit":          true,
+		"submit_selector": "#submit",
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, mockPlaywright.FillFormCallCount(),
+		"FillForm should be called exactly once with the full batch")
+	assert.Equal(t, 0, mockPlaywright.ClickElementCallCount(),
+		"submit should be delegated to playwright.FillForm, not a separate ClickElement")
+
+	_, _, gotFields, gotSubmit, gotSelector := mockPlaywright.FillFormArgsForCall(0)
+	assert.Len(t, gotFields, 3)
+	assert.True(t, gotSubmit)
+	assert.Equal(t, "#submit", gotSelector)
 }
 
 func TestFillFormTool_ValidateFieldTypes(t *testing.T) {
@@ -209,12 +243,13 @@ func TestFillFormTool_ValidateFieldTypes(t *testing.T) {
 			logger := zap.NewNop()
 			mockPlaywright := &mocks.FakeBrowserAutomation{}
 
-			tool := &FillFormTool{
-				logger:     logger,
-				playwright: mockPlaywright,
-			}
+			session := &playwright.BrowserSession{ID: "test-session"}
+			mockPlaywright.GetOrCreateTaskSessionReturns(session, nil)
+			mockPlaywright.GetSessionReturns(session, nil)
+			mockPlaywright.FillFormReturns(nil)
 
-			args := map[string]any{
+			tool := &FillFormTool{logger: logger, playwright: mockPlaywright}
+			_, err := tool.FillFormHandler(context.Background(), map[string]any{
 				"fields": []any{
 					map[string]any{
 						"selector": "#test",
@@ -222,14 +257,7 @@ func TestFillFormTool_ValidateFieldTypes(t *testing.T) {
 						"type":     fieldType,
 					},
 				},
-			}
-
-			session := &playwright.BrowserSession{ID: "test-session"}
-			mockPlaywright.GetOrCreateTaskSessionReturns(session, nil)
-			mockPlaywright.GetSessionReturns(session, nil)
-			mockPlaywright.FillFormReturns(nil)
-
-			_, err := tool.FillFormHandler(context.Background(), args)
+			})
 
 			if err != nil {
 				assert.NotContains(t, err.Error(), "invalid type")
@@ -242,29 +270,23 @@ func TestFillFormTool_DefaultFieldType(t *testing.T) {
 	logger := zap.NewNop()
 	mockPlaywright := &mocks.FakeBrowserAutomation{}
 
-	tool := &FillFormTool{
-		logger:     logger,
-		playwright: mockPlaywright,
-	}
+	session := &playwright.BrowserSession{ID: "test-session"}
+	mockPlaywright.GetOrCreateTaskSessionReturns(session, nil)
+	mockPlaywright.GetSessionReturns(session, nil)
+	mockPlaywright.FillFormReturns(nil)
 
-	args := map[string]any{
+	tool := &FillFormTool{logger: logger, playwright: mockPlaywright}
+	_, err := tool.FillFormHandler(context.Background(), map[string]any{
 		"fields": []any{
 			map[string]any{
 				"selector": "#test",
 				"value":    "test",
 			},
 		},
-	}
+	})
 
-	session := &playwright.BrowserSession{ID: "test-session"}
-	mockPlaywright.GetOrCreateTaskSessionReturns(session, nil)
-	mockPlaywright.GetSessionReturns(session, nil)
-	mockPlaywright.FillFormReturns(nil)
+	assert.NoError(t, err)
 
-	_, err := tool.FillFormHandler(context.Background(), args)
-
-	if err != nil {
-		assert.NotContains(t, err.Error(), "invalid type")
-		assert.NotContains(t, err.Error(), "type is required")
-	}
+	_, _, gotFields, _, _ := mockPlaywright.FillFormArgsForCall(0)
+	assert.Equal(t, "text", gotFields[0]["type"], "type should default to text")
 }

--- a/tools/handle_authentication.go
+++ b/tools/handle_authentication.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"fmt"
 
-	server "github.com/inference-gateway/adk/server"
-	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
 	zap "go.uber.org/zap"
+
+	server "github.com/inference-gateway/adk/server"
+
+	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
 )
+
+var validAuthTypes = []string{"basic", "form", "oauth"}
 
 // HandleAuthenticationTool struct holds the tool with dependencies
 type HandleAuthenticationTool struct {
@@ -23,7 +27,7 @@ func NewHandleAuthenticationTool(logger *zap.Logger, playwright playwright.Brows
 	}
 	return server.NewBasicTool(
 		"handle_authentication",
-		"Handle various authentication scenarios including basic auth, OAuth, and custom login forms",
+		"NOT YET IMPLEMENTED: This tool currently returns an error explaining that authentication is not wired through. For basic auth, configure HTTP credentials at the browser context level. For form login, compose navigate_to_url + fill_form + click_element. For OAuth, run the flow manually with the above primitives.",
 		map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -62,23 +66,30 @@ func NewHandleAuthenticationTool(logger *zap.Logger, playwright playwright.Brows
 	)
 }
 
-// HandleAuthenticationHandler handles the handle_authentication tool execution
+// HandleAuthenticationHandler returns an explicit "not implemented" error
+// instead of the previous silent no-op TODO that returned a fake-success
+// payload. We still validate args["type"] so the caller gets a clearer
+// signal when they passed something garbage in addition to hitting an
+// unimplemented tool.
+//
+// The plumbing in internal/playwright.HandleAuthentication exists but the
+// wiring between this tool's args (login_url, *_selector, ...) and the
+// service's expected layout (selectors map[string]string) was never
+// completed. Until it is, fail loudly.
 func (s *HandleAuthenticationTool) HandleAuthenticationHandler(ctx context.Context, args map[string]any) (string, error) {
-	// TODO: Implement handle_authentication logic
-	// Handle various authentication scenarios including basic auth, OAuth, and custom login forms
+	authType, err := requiredString(args, "type")
+	if err != nil {
+		return "", err
+	}
+	if !oneOf(authType, validAuthTypes...) {
+		return "", fmt.Errorf("invalid auth type: %s. Must be one of: %v", authType, validAuthTypes)
+	}
 
-	// Example of using dependencies:
-	// s.logger.SomeMethod(ctx, ...)
-	// s.playwright.SomeMethod(ctx, ...)
+	s.logger.Warn("handle_authentication invoked but not implemented",
+		zap.String("auth_type", authType))
 
-	// Extract parameters from args
-	// login_url := args["login_url"].(string)
-	// password := args["password"].(string)
-	// password_selector := args["password_selector"].(string)
-	// submit_selector := args["submit_selector"].(string)
-	// type := args["type"].(string)
-	// username := args["username"].(string)
-	// username_selector := args["username_selector"].(string)
-
-	return fmt.Sprintf(`{"result": "TODO: Implement handle_authentication logic", "input": %+v}`, args), nil
+	return "", fmt.Errorf("handle_authentication is not yet implemented (auth_type=%s). "+
+		"For basic auth, configure HTTP credentials at the browser context level. "+
+		"For form login, compose navigate_to_url + fill_form + click_element instead. "+
+		"For OAuth, drive the flow manually with the same primitives", authType)
 }

--- a/tools/handle_authentication_test.go
+++ b/tools/handle_authentication_test.go
@@ -1,0 +1,66 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+
+	zap "go.uber.org/zap"
+
+	mocks "github.com/inference-gateway/browser-agent/internal/playwright/mocks"
+)
+
+func TestHandleAuthenticationTool_HandleAuthenticationHandler(t *testing.T) {
+	logger := zap.NewNop()
+	mockPlaywright := &mocks.FakeBrowserAutomation{}
+	tool := &HandleAuthenticationTool{logger: logger, playwright: mockPlaywright}
+
+	tests := []struct {
+		name          string
+		args          map[string]any
+		errorContains string
+	}{
+		{
+			name:          "missing type",
+			args:          map[string]any{},
+			errorContains: "type parameter is required",
+		},
+		{
+			name:          "invalid type",
+			args:          map[string]any{"type": "saml"},
+			errorContains: "invalid auth type",
+		},
+		{
+			name:          "valid type still returns not-implemented",
+			args:          map[string]any{"type": "form", "username": "u", "password": "p"},
+			errorContains: "not yet implemented",
+		},
+		{
+			name:          "basic returns not-implemented",
+			args:          map[string]any{"type": "basic"},
+			errorContains: "not yet implemented",
+		},
+		{
+			name:          "oauth returns not-implemented",
+			args:          map[string]any{"type": "oauth"},
+			errorContains: "not yet implemented",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tool.HandleAuthenticationHandler(context.Background(), tt.args)
+			assert.Error(t, err)
+			assert.Empty(t, result)
+			assert.Contains(t, err.Error(), tt.errorContains)
+		})
+	}
+
+	// Defense-in-depth: even when called, the tool MUST NOT touch the
+	// playwright service. Previously the tool was a no-op that bypassed
+	// the service entirely; the new explicit error preserves that
+	// no-side-effects property.
+	assert.Equal(t, 0, mockPlaywright.HandleAuthenticationCallCount(),
+		"handle_authentication must not call the playwright service while unimplemented")
+}

--- a/tools/navigate_to_url.go
+++ b/tools/navigate_to_url.go
@@ -6,10 +6,14 @@ import (
 	"net/url"
 	"time"
 
-	server "github.com/inference-gateway/adk/server"
-	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
 	zap "go.uber.org/zap"
+
+	server "github.com/inference-gateway/adk/server"
+
+	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
 )
+
+var validWaitConditions = []string{"domcontentloaded", "load", "networkidle"}
 
 // NavigateToURLTool struct holds the tool with dependencies
 type NavigateToURLTool struct {
@@ -30,7 +34,7 @@ func NewNavigateToURLTool(logger *zap.Logger, playwright playwright.BrowserAutom
 			"type": "object",
 			"properties": map[string]any{
 				"timeout": map[string]any{
-					"default":     30000,
+					"default":     defaultTimeoutMs,
 					"description": "Maximum navigation timeout in milliseconds",
 					"type":        "integer",
 				},
@@ -52,35 +56,32 @@ func NewNavigateToURLTool(logger *zap.Logger, playwright playwright.BrowserAutom
 
 // NavigateToURLHandler handles the navigate_to_url tool execution
 func (s *NavigateToURLTool) NavigateToURLHandler(ctx context.Context, args map[string]any) (string, error) {
-	url, ok := args["url"].(string)
-	if !ok || url == "" {
-		return "", fmt.Errorf("url parameter is required and must be a non-empty string")
+	rawURL, err := requiredString(args, "url")
+	if err != nil {
+		return "", err
 	}
 
-	normalizedURL, err := s.validateAndNormalizeURL(url)
+	targetURL, err := s.validateAndNormalizeURL(rawURL)
 	if err != nil {
-		s.logger.Error("invalid URL provided", zap.String("url", url), zap.Error(err))
+		s.logger.Error("invalid URL provided", zap.String("url", rawURL), zap.Error(err))
 		return "", fmt.Errorf("invalid URL: %w", err)
 	}
-	url = normalizedURL
 
-	waitUntil := "load"
-	if wu, ok := args["wait_until"].(string); ok && wu != "" {
-		if !s.isValidWaitCondition(wu) {
-			return "", fmt.Errorf("invalid wait_until value: %s. Must be one of: domcontentloaded, load, networkidle", wu)
-		}
-		waitUntil = wu
+	waitUntil, err := stringArg(args, "wait_until", "load")
+	if err != nil {
+		return "", err
+	}
+	if !oneOf(waitUntil, validWaitConditions...) {
+		return "", fmt.Errorf("invalid wait_until value: %s. Must be one of: %v", waitUntil, validWaitConditions)
 	}
 
-	timeout := 30000
-	if t, ok := args["timeout"].(int); ok && t > 0 {
-		timeout = t
-	} else if tf, ok := args["timeout"].(float64); ok && tf > 0 {
-		timeout = int(tf)
+	timeout, err := boundedIntArg(args, "timeout", defaultTimeoutMs, minTimeoutMs, maxTimeoutMs)
+	if err != nil {
+		return "", err
 	}
 
 	s.logger.Info("navigating to URL",
-		zap.String("url", url),
+		zap.String("url", targetURL),
 		zap.String("wait_until", waitUntil),
 		zap.Int("timeout_ms", timeout))
 
@@ -91,37 +92,30 @@ func (s *NavigateToURLTool) NavigateToURLHandler(ctx context.Context, args map[s
 	}
 
 	timeoutDuration := time.Duration(timeout) * time.Millisecond
-	err = s.playwright.NavigateToURL(ctx, session.ID, url, waitUntil, timeoutDuration)
-	if err != nil {
+	if err := s.playwright.NavigateToURL(ctx, session.ID, targetURL, waitUntil, timeoutDuration); err != nil {
 		s.logger.Error("navigation failed",
-			zap.String("url", url),
+			zap.String("url", targetURL),
 			zap.String("sessionID", session.ID),
 			zap.Error(err))
 		return "", fmt.Errorf("navigation failed: %w", err)
 	}
 
 	s.logger.Info("navigation completed successfully",
-		zap.String("url", url),
+		zap.String("url", targetURL),
 		zap.String("sessionID", session.ID))
 
-	response := map[string]any{
+	return marshalResponse(map[string]any{
 		"success":    true,
-		"url":        url,
+		"url":        targetURL,
 		"wait_until": waitUntil,
 		"timeout_ms": timeout,
 		"session_id": session.ID,
 		"message":    "Navigation completed successfully",
-	}
-
-	return fmt.Sprintf(`%+v`, response), nil
+	})
 }
 
 // validateAndNormalizeURL validates that the provided URL is well-formed and supported, returning the normalized URL
 func (s *NavigateToURLTool) validateAndNormalizeURL(urlStr string) (string, error) {
-	if urlStr == "" {
-		return "", fmt.Errorf("URL cannot be empty")
-	}
-
 	parsedURL, err := url.Parse(urlStr)
 	if err != nil {
 		return "", fmt.Errorf("invalid URL format: %w", err)
@@ -144,15 +138,4 @@ func (s *NavigateToURLTool) validateAndNormalizeURL(urlStr string) (string, erro
 	}
 
 	return parsedURL.String(), nil
-}
-
-// isValidWaitCondition validates the wait_until parameter
-func (s *NavigateToURLTool) isValidWaitCondition(condition string) bool {
-	validConditions := []string{"domcontentloaded", "load", "networkidle"}
-	for _, valid := range validConditions {
-		if condition == valid {
-			return true
-		}
-	}
-	return false
 }

--- a/tools/navigate_to_url_test.go
+++ b/tools/navigate_to_url_test.go
@@ -2,13 +2,16 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/inference-gateway/browser-agent/internal/playwright"
-	"github.com/inference-gateway/browser-agent/internal/playwright/mocks"
-	"go.uber.org/zap/zaptest"
+	zaptest "go.uber.org/zap/zaptest"
+
+	mocks "github.com/inference-gateway/browser-agent/internal/playwright/mocks"
+
+	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
 )
 
 func TestNavigateToURLTool_NavigateToURLHandler(t *testing.T) {
@@ -34,7 +37,6 @@ func TestNavigateToURLTool_NavigateToURLHandler(t *testing.T) {
 		args        map[string]any
 		expectError bool
 		errorMsg    string
-		setup       func()
 	}{
 		{
 			name: "successful navigation with default parameters",
@@ -73,7 +75,7 @@ func TestNavigateToURLTool_NavigateToURLHandler(t *testing.T) {
 				"url": "",
 			},
 			expectError: true,
-			errorMsg:    "url parameter is required",
+			errorMsg:    "non-empty string",
 		},
 		{
 			name: "invalid URL parameter type",
@@ -81,7 +83,7 @@ func TestNavigateToURLTool_NavigateToURLHandler(t *testing.T) {
 				"url": 123,
 			},
 			expectError: true,
-			errorMsg:    "url parameter is required",
+			errorMsg:    "must be a string",
 		},
 		{
 			name: "invalid wait_until parameter",
@@ -117,21 +119,18 @@ func TestNavigateToURLTool_NavigateToURLHandler(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "negative timeout parameter",
+			name: "negative timeout is rejected with explicit error",
 			args: map[string]any{
 				"url":     "https://example.com",
 				"timeout": -1000,
 			},
-			expectError: false,
+			expectError: true,
+			errorMsg:    "timeout must be between",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.setup != nil {
-				tt.setup()
-			}
-
 			ctx := context.Background()
 			result, err := tool.NavigateToURLHandler(ctx, tt.args)
 
@@ -141,13 +140,21 @@ func TestNavigateToURLTool_NavigateToURLHandler(t *testing.T) {
 				} else if tt.errorMsg != "" && !strings.Contains(err.Error(), tt.errorMsg) {
 					t.Errorf("expected error message to contain %q, got %q", tt.errorMsg, err.Error())
 				}
-			} else {
-				if err != nil {
-					t.Errorf("expected no error but got: %v", err)
-				}
-				if result == "" {
-					t.Errorf("expected non-empty result")
-				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected no error but got: %v", err)
+			}
+			if result == "" {
+				t.Fatalf("expected non-empty result")
+			}
+			var parsed map[string]any
+			if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+				t.Fatalf("expected valid JSON response, got %q: %v", result, err)
+			}
+			if got, _ := parsed["success"].(bool); !got {
+				t.Errorf("expected success=true in response, got %v", parsed["success"])
 			}
 		})
 	}
@@ -184,7 +191,7 @@ func TestNavigateToURLTool_validateAndNormalizeURL(t *testing.T) {
 			expected: "https://example.com/path",
 		},
 		{
-			name:        "empty URL",
+			name:        "empty URL falls through to host check",
 			input:       "",
 			expectError: true,
 		},
@@ -220,32 +227,6 @@ func TestNavigateToURLTool_validateAndNormalizeURL(t *testing.T) {
 				if result != tt.expected {
 					t.Errorf("expected %q, got %q", tt.expected, result)
 				}
-			}
-		})
-	}
-}
-
-func TestNavigateToURLTool_isValidWaitCondition(t *testing.T) {
-	logger := zaptest.NewLogger(t)
-	tool := &NavigateToURLTool{logger: logger}
-
-	tests := []struct {
-		condition string
-		expected  bool
-	}{
-		{"domcontentloaded", true},
-		{"load", true},
-		{"networkidle", true},
-		{"invalid", false},
-		{"", false},
-		{"LOAD", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.condition, func(t *testing.T) {
-			result := tool.isValidWaitCondition(tt.condition)
-			if result != tt.expected {
-				t.Errorf("expected %v for condition %q, got %v", tt.expected, tt.condition, result)
 			}
 		})
 	}

--- a/tools/take_screenshot.go
+++ b/tools/take_screenshot.go
@@ -2,16 +2,17 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
+	zap "go.uber.org/zap"
+
 	server "github.com/inference-gateway/adk/server"
 	types "github.com/inference-gateway/adk/types"
+
 	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
-	zap "go.uber.org/zap"
 )
 
 // TakeScreenshotTool struct holds the tool with dependencies
@@ -63,40 +64,33 @@ func NewTakeScreenshotTool(logger *zap.Logger, playwright playwright.BrowserAuto
 
 // TakeScreenshotHandler handles the take_screenshot tool execution
 func (s *TakeScreenshotTool) TakeScreenshotHandler(ctx context.Context, args map[string]any) (string, error) {
+	fullPage, err := boolArg(args, "full_page", false)
+	if err != nil {
+		return "", err
+	}
 
-	generatedPath, err := s.generateDeterministicPath(args)
+	imageType, err := stringArg(args, "type", "png")
+	if err != nil {
+		return "", err
+	}
+	if !oneOf(imageType, "png", "jpeg") {
+		return "", fmt.Errorf("invalid image type: %s. Must be 'png' or 'jpeg'", imageType)
+	}
+
+	quality, err := boundedIntArg(args, "quality", defaultJPEGQuality, minJPEGQuality, maxJPEGQuality)
+	if err != nil {
+		return "", err
+	}
+
+	selector, err := stringArg(args, "selector", "")
+	if err != nil {
+		return "", err
+	}
+
+	generatedPath, err := s.generateDeterministicPath(fullPage, selector, imageType)
 	if err != nil {
 		s.logger.Error("failed to generate screenshot path", zap.Error(err))
 		return "", fmt.Errorf("failed to generate screenshot path: %w", err)
-	}
-
-	fullPage := false
-	if fp, ok := args["full_page"].(bool); ok {
-		fullPage = fp
-	}
-
-	quality := 80
-	if q, ok := args["quality"].(int); ok {
-		quality = q
-	} else if qf, ok := args["quality"].(float64); ok {
-		quality = int(qf)
-	}
-
-	imageType := "png"
-	if t, ok := args["type"].(string); ok && t != "" {
-		if !s.isValidImageType(t) {
-			return "", fmt.Errorf("invalid image type: %s. Must be 'png' or 'jpeg'", t)
-		}
-		imageType = t
-	}
-
-	if imageType == "jpeg" && (quality < 0 || quality > 100) {
-		return "", fmt.Errorf("quality must be between 0 and 100 for JPEG images, got %d", quality)
-	}
-
-	selector := ""
-	if s, ok := args["selector"].(string); ok {
-		selector = s
 	}
 
 	s.logger.Info("taking screenshot",
@@ -125,94 +119,66 @@ func (s *TakeScreenshotTool) TakeScreenshotHandler(ctx context.Context, args map
 		zap.String("sessionID", session.ID),
 		zap.String("path", generatedPath))
 
+	response := map[string]any{
+		"success":    true,
+		"path":       generatedPath,
+		"filename":   filepath.Base(generatedPath),
+		"full_page":  fullPage,
+		"type":       imageType,
+		"quality":    quality,
+		"selector":   selector,
+		"session_id": session.ID,
+		"timestamp":  s.getCurrentTimestamp(),
+	}
+
 	artifactURL, artifactID, err := s.createArtifactFromScreenshot(ctx, generatedPath, imageType)
 	if err != nil {
 		s.logger.Debug("artifact creation skipped or failed, returning file path only",
 			zap.Error(err),
 			zap.String("path", generatedPath))
-
-		response := map[string]any{
-			"success":    true,
-			"path":       generatedPath,
-			"filename":   filepath.Base(generatedPath),
-			"full_page":  fullPage,
-			"type":       imageType,
-			"quality":    quality,
-			"selector":   selector,
-			"session_id": session.ID,
-			"timestamp":  s.getCurrentTimestamp(),
-			"message":    fmt.Sprintf("Screenshot captured successfully and saved to %s", generatedPath),
-		}
-
-		responseJSON, err := json.Marshal(response)
-		if err != nil {
-			return "", fmt.Errorf("failed to marshal response: %w", err)
-		}
-		return string(responseJSON), nil
+		response["message"] = fmt.Sprintf("Screenshot captured successfully and saved to %s", generatedPath)
+		return marshalResponse(response)
 	}
 
-	response := map[string]any{
-		"success":     true,
-		"path":        generatedPath,
-		"filename":    filepath.Base(generatedPath),
-		"full_page":   fullPage,
-		"type":        imageType,
-		"quality":     quality,
-		"selector":    selector,
-		"session_id":  session.ID,
-		"timestamp":   s.getCurrentTimestamp(),
-		"artifact_id": artifactID,
-		"url":         artifactURL,
-		"message":     fmt.Sprintf("Screenshot captured successfully. Download URL: %s", artifactURL),
-	}
-
-	responseJSON, err := json.Marshal(response)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal response: %w", err)
-	}
-
-	return string(responseJSON), nil
+	response["artifact_id"] = artifactID
+	response["url"] = artifactURL
+	response["message"] = fmt.Sprintf("Screenshot captured successfully. Download URL: %s", artifactURL)
+	return marshalResponse(response)
 }
 
-// generateDeterministicPath generates a deterministic file path for the screenshot
-func (s *TakeScreenshotTool) generateDeterministicPath(args map[string]any) (string, error) {
+// generateDeterministicPath generates a deterministic file path for the screenshot.
+// safeSelector is sliced by runes (not bytes) so multibyte selectors don't
+// produce invalid-UTF-8 filenames.
+func (s *TakeScreenshotTool) generateDeterministicPath(fullPage bool, selector, imageType string) (string, error) {
 	if err := os.MkdirAll(s.screenshotDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create screenshots directory: %w", err)
-	}
-
-	imageType := "png"
-	if t, ok := args["type"].(string); ok && t != "" {
-		imageType = t
 	}
 
 	timestamp := time.Now().Format("2006-01-02_15-04-05.000")
 
 	var filename string
-	if fullPage, ok := args["full_page"].(bool); ok && fullPage {
+	switch {
+	case fullPage:
 		filename = fmt.Sprintf("fullpage_%s.%s", timestamp, imageType)
-	} else if selector, ok := args["selector"].(string); ok && selector != "" {
-		safeSelector := filepath.Base(selector)
-		if len(safeSelector) > 20 {
-			safeSelector = safeSelector[:20]
-		}
+	case selector != "":
+		safeSelector := truncateRunes(filepath.Base(selector), screenshotSelectorMaxRunes)
 		filename = fmt.Sprintf("element_%s_%s.%s", safeSelector, timestamp, imageType)
-	} else {
+	default:
 		filename = fmt.Sprintf("viewport_%s.%s", timestamp, imageType)
 	}
 
-	fullPath := filepath.Join(s.screenshotDir, filename)
-	return fullPath, nil
+	return filepath.Join(s.screenshotDir, filename), nil
 }
 
-// isValidImageType validates the image format
-func (s *TakeScreenshotTool) isValidImageType(imageType string) bool {
-	validTypes := []string{"png", "jpeg"}
-	for _, valid := range validTypes {
-		if imageType == valid {
-			return true
-		}
+// truncateRunes returns s truncated to at most maxRunes runes (not bytes).
+// Slicing a byte string at an arbitrary index can split a multibyte rune
+// and produce invalid UTF-8; this helper does it safely.
+func truncateRunes(s string, maxRunes int) string {
+	runes := []rune(s)
+	if len(runes) > maxRunes {
+		return string(runes[:maxRunes])
 	}
-	return false
+	return s
 }
 
 // getMimeType returns the MIME type for the given image format

--- a/tools/take_screenshot_test.go
+++ b/tools/take_screenshot_test.go
@@ -9,14 +9,23 @@ import (
 	"testing"
 	"time"
 
+	zap "go.uber.org/zap"
+
+	mocks "github.com/inference-gateway/browser-agent/internal/playwright/mocks"
+
 	config "github.com/inference-gateway/browser-agent/config"
 	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
-	mocks "github.com/inference-gateway/browser-agent/internal/playwright/mocks"
-	zap "go.uber.org/zap"
 )
 
-func createTestTool() *TakeScreenshotTool {
-	logger := zap.NewNop()
+// newTestTool returns a TakeScreenshotTool wired with a mock playwright
+// service that writes a stub file to a per-test temporary directory.
+// Using t.TempDir() instead of a hardcoded "test_screenshots" directory
+// avoids parallel-test collisions and removes the need for explicit
+// cleanup at the end of each test (the harness deletes the dir).
+func newTestTool(t *testing.T) *TakeScreenshotTool {
+	t.Helper()
+	dir := t.TempDir()
+
 	mockPlaywright := &mocks.FakeBrowserAutomation{}
 
 	session := &playwright.BrowserSession{
@@ -27,34 +36,28 @@ func createTestTool() *TakeScreenshotTool {
 	mockPlaywright.GetOrCreateTaskSessionReturns(session, nil)
 	mockPlaywright.GetSessionReturns(session, nil)
 	mockPlaywright.TakeScreenshotCalls(func(ctx context.Context, sessionID, path string, fullPage bool, selector string, format string, quality int) error {
-		dir := filepath.Dir(path)
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 			return err
 		}
 		return os.WriteFile(path, []byte("mock screenshot data"), 0644)
 	})
 	mockPlaywright.GetConfigReturns(&config.Config{
 		Browser: config.BrowserConfig{
-			DataDir: "test_screenshots",
+			DataDir: dir,
 		},
 	})
 
 	return &TakeScreenshotTool{
-		logger:        logger,
+		logger:        zap.NewNop(),
 		playwright:    mockPlaywright,
-		screenshotDir: "test_screenshots",
+		screenshotDir: dir,
 	}
 }
 
 func TestTakeScreenshotHandler_BasicFunctionality(t *testing.T) {
-	tool := createTestTool()
+	tool := newTestTool(t)
 
-	args := map[string]any{}
-
-	ctx := context.Background()
-
-	result, err := tool.TakeScreenshotHandler(ctx, args)
-
+	result, err := tool.TakeScreenshotHandler(context.Background(), map[string]any{})
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
@@ -68,42 +71,21 @@ func TestTakeScreenshotHandler_BasicFunctionality(t *testing.T) {
 		t.Errorf("Expected success to be true, got: %v", response["success"])
 	}
 
-	resultPath, ok := response["path"].(string)
-	if !ok {
-		t.Errorf("Expected path in response, got: %v", response["path"])
-	}
-
+	resultPath, _ := response["path"].(string)
 	if !strings.Contains(resultPath, "viewport_") {
 		t.Errorf("Expected viewport screenshot path, got: %s", resultPath)
 	}
 
-	resultFilename, ok := response["filename"].(string)
-	if !ok {
-		t.Errorf("Expected filename in response, got: %v", response["filename"])
-	}
-
-	if !strings.Contains(resultFilename, "viewport_") {
-		t.Errorf("Expected viewport screenshot filename, got: %s", resultFilename)
-	}
-
+	resultFilename, _ := response["filename"].(string)
 	if !strings.HasSuffix(resultFilename, ".png") {
 		t.Errorf("Expected .png extension in filename, got: %s", resultFilename)
 	}
-
-	_ = os.RemoveAll("test_screenshots")
 }
 
 func TestTakeScreenshotHandler_FullPageScreenshot(t *testing.T) {
-	tool := createTestTool()
+	tool := newTestTool(t)
 
-	args := map[string]any{
-		"full_page": true,
-	}
-
-	ctx := context.Background()
-
-	result, err := tool.TakeScreenshotHandler(ctx, args)
-
+	result, err := tool.TakeScreenshotHandler(context.Background(), map[string]any{"full_page": true})
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
@@ -113,30 +95,22 @@ func TestTakeScreenshotHandler_FullPageScreenshot(t *testing.T) {
 		t.Fatalf("Failed to parse response JSON: %v", err)
 	}
 
-	if fullPage, ok := response["full_page"].(bool); !ok || !fullPage {
+	if fullPage, _ := response["full_page"].(bool); !fullPage {
 		t.Errorf("Expected full_page to be true, got: %v", response["full_page"])
 	}
 
-	resultFilename, ok := response["filename"].(string)
-	if !ok || !strings.Contains(resultFilename, "fullpage_") {
+	if resultFilename, _ := response["filename"].(string); !strings.Contains(resultFilename, "fullpage_") {
 		t.Errorf("Expected fullpage screenshot filename, got: %s", resultFilename)
 	}
-
-	_ = os.RemoveAll("test_screenshots")
 }
 
 func TestTakeScreenshotHandler_JPEGWithQuality(t *testing.T) {
-	tool := createTestTool()
+	tool := newTestTool(t)
 
-	args := map[string]any{
+	result, err := tool.TakeScreenshotHandler(context.Background(), map[string]any{
 		"type":    "jpeg",
 		"quality": 95,
-	}
-
-	ctx := context.Background()
-
-	result, err := tool.TakeScreenshotHandler(ctx, args)
-
+	})
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
@@ -146,33 +120,25 @@ func TestTakeScreenshotHandler_JPEGWithQuality(t *testing.T) {
 		t.Fatalf("Failed to parse response JSON: %v", err)
 	}
 
-	if imageType, ok := response["type"].(string); !ok || imageType != "jpeg" {
+	if imageType, _ := response["type"].(string); imageType != "jpeg" {
 		t.Errorf("Expected type to be jpeg, got: %v", response["type"])
 	}
 
-	if quality, ok := response["quality"].(float64); !ok || int(quality) != 95 {
+	if quality, _ := response["quality"].(float64); int(quality) != 95 {
 		t.Errorf("Expected quality to be 95, got: %v", response["quality"])
 	}
 
-	resultFilename, ok := response["filename"].(string)
-	if !ok || !strings.HasSuffix(resultFilename, ".jpeg") {
+	if resultFilename, _ := response["filename"].(string); !strings.HasSuffix(resultFilename, ".jpeg") {
 		t.Errorf("Expected .jpeg extension in filename, got: %s", resultFilename)
 	}
-
-	_ = os.RemoveAll("test_screenshots")
 }
 
 func TestTakeScreenshotHandler_ElementSelector(t *testing.T) {
-	tool := createTestTool()
+	tool := newTestTool(t)
 
-	args := map[string]any{
+	result, err := tool.TakeScreenshotHandler(context.Background(), map[string]any{
 		"selector": "#main-content",
-	}
-
-	ctx := context.Background()
-
-	result, err := tool.TakeScreenshotHandler(ctx, args)
-
+	})
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
@@ -182,29 +148,21 @@ func TestTakeScreenshotHandler_ElementSelector(t *testing.T) {
 		t.Fatalf("Failed to parse response JSON: %v", err)
 	}
 
-	if selector, ok := response["selector"].(string); !ok || selector != "#main-content" {
+	if selector, _ := response["selector"].(string); selector != "#main-content" {
 		t.Errorf("Expected selector to be #main-content, got: %v", response["selector"])
 	}
 
-	resultFilename, ok := response["filename"].(string)
-	if !ok || !strings.Contains(resultFilename, "element_") {
+	if resultFilename, _ := response["filename"].(string); !strings.Contains(resultFilename, "element_") {
 		t.Errorf("Expected element screenshot filename, got: %s", resultFilename)
 	}
-
-	_ = os.RemoveAll("test_screenshots")
 }
 
 func TestTakeScreenshotHandler_DeterministicPath(t *testing.T) {
-	tool := createTestTool()
+	tool := newTestTool(t)
 
-	args := map[string]any{}
-
-	ctx := context.Background()
-
-	result, err := tool.TakeScreenshotHandler(ctx, args)
-
+	result, err := tool.TakeScreenshotHandler(context.Background(), map[string]any{})
 	if err != nil {
-		t.Fatalf("Expected no error for deterministic path generation, got: %v", err)
+		t.Fatalf("Expected no error, got: %v", err)
 	}
 
 	var response map[string]any
@@ -215,141 +173,83 @@ func TestTakeScreenshotHandler_DeterministicPath(t *testing.T) {
 	if _, ok := response["filename"]; !ok {
 		t.Error("Expected filename to be generated in response")
 	}
-
-	_ = os.RemoveAll("test_screenshots")
 }
 
 func TestTakeScreenshotHandler_InvalidImageType(t *testing.T) {
-	tool := createTestTool()
-
-	args := map[string]any{
-		"type": "gif",
-	}
-
-	ctx := context.Background()
-
-	_, err := tool.TakeScreenshotHandler(ctx, args)
-
+	tool := newTestTool(t)
+	_, err := tool.TakeScreenshotHandler(context.Background(), map[string]any{"type": "gif"})
 	if err == nil {
-		t.Error("Expected error for invalid image type, got nil")
+		t.Fatal("Expected error for invalid image type, got nil")
 	}
-
-	expectedMsg := "invalid image type: gif. Must be 'png' or 'jpeg'"
-	if err.Error() != expectedMsg {
-		t.Errorf("Expected error message '%s', got: %v", expectedMsg, err)
+	if !strings.Contains(err.Error(), "invalid image type") {
+		t.Errorf("Expected invalid image type error, got: %v", err)
 	}
-
-	_ = os.RemoveAll("test_screenshots")
 }
 
 func TestTakeScreenshotHandler_InvalidQuality(t *testing.T) {
-	tool := createTestTool()
-
-	args := map[string]any{
+	tool := newTestTool(t)
+	_, err := tool.TakeScreenshotHandler(context.Background(), map[string]any{
 		"type":    "jpeg",
 		"quality": 150,
-	}
-
-	ctx := context.Background()
-
-	_, err := tool.TakeScreenshotHandler(ctx, args)
-
+	})
 	if err == nil {
-		t.Error("Expected error for invalid quality, got nil")
+		t.Fatal("Expected error for invalid quality, got nil")
 	}
-
-	expectedMsg := "quality must be between 0 and 100 for JPEG images, got 150"
-	if err.Error() != expectedMsg {
-		t.Errorf("Expected error message '%s', got: %v", expectedMsg, err)
+	if !strings.Contains(err.Error(), "quality must be between") {
+		t.Errorf("Expected quality bound error, got: %v", err)
 	}
-
-	_ = os.RemoveAll("test_screenshots")
 }
 
 func TestGenerateDeterministicPath(t *testing.T) {
-	tool := createTestTool()
+	tool := newTestTool(t)
 
 	tests := []struct {
-		name     string
-		args     map[string]any
-		expected string
+		name      string
+		fullPage  bool
+		selector  string
+		imageType string
+		expected  string
 	}{
-		{
-			name:     "viewport screenshot",
-			args:     map[string]any{},
-			expected: "viewport_",
-		},
-		{
-			name:     "fullpage screenshot",
-			args:     map[string]any{"full_page": true},
-			expected: "fullpage_",
-		},
-		{
-			name:     "element screenshot",
-			args:     map[string]any{"selector": "#main"},
-			expected: "element_",
-		},
-		{
-			name:     "jpeg format",
-			args:     map[string]any{"type": "jpeg"},
-			expected: ".jpeg",
-		},
+		{name: "viewport screenshot", imageType: "png", expected: "viewport_"},
+		{name: "fullpage screenshot", fullPage: true, imageType: "png", expected: "fullpage_"},
+		{name: "element screenshot", selector: "#main", imageType: "png", expected: "element_"},
+		{name: "jpeg format", imageType: "jpeg", expected: ".jpeg"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := tool.generateDeterministicPath(tt.args)
-
+			result, err := tool.generateDeterministicPath(tt.fullPage, tt.selector, tt.imageType)
 			if err != nil {
-				t.Errorf("Expected no error, got: %v", err)
-				return
+				t.Fatalf("Expected no error, got: %v", err)
 			}
-
-			if result == "" {
-				t.Error("Expected non-empty result")
-				return
-			}
-
 			if !strings.Contains(result, tt.expected) {
-				t.Errorf("Expected path to contain '%s', got: %s", tt.expected, result)
+				t.Errorf("Expected path to contain %q, got: %s", tt.expected, result)
 			}
-
-			if !strings.HasPrefix(result, "test_screenshots/") {
-				t.Errorf("Expected path to start with test_screenshots/, got: %s", result)
-			}
-
-			_ = os.RemoveAll("test_screenshots")
 		})
 	}
 }
 
-func TestIsValidImageType(t *testing.T) {
-	tool := createTestTool()
-
-	tests := []struct {
-		imageType string
-		expected  bool
-	}{
-		{"png", true},
-		{"jpeg", true},
-		{"jpg", false},
-		{"gif", false},
-		{"webp", false},
-		{"", false},
+// TestTruncateRunes_MultibyteSafe confirms that the truncation helper
+// does not split multibyte UTF-8 sequences. Slicing the raw byte string
+// would produce invalid UTF-8 in the filename.
+func TestTruncateRunes_MultibyteSafe(t *testing.T) {
+	in := "日本語テスト文字列abcdef" // 13 runes, > 20 bytes
+	out := truncateRunes(in, 8)
+	if len([]rune(out)) != 8 {
+		t.Fatalf("expected 8 runes, got %d (output=%q)", len([]rune(out)), out)
+	}
+	if out != "日本語テスト文字" {
+		t.Errorf("unexpected truncation result: %q", out)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.imageType, func(t *testing.T) {
-			result := tool.isValidImageType(tt.imageType)
-			if result != tt.expected {
-				t.Errorf("Expected %v for %s, got %v", tt.expected, tt.imageType, result)
-			}
-		})
+	// Short string should be returned unchanged.
+	if got := truncateRunes("abc", 10); got != "abc" {
+		t.Errorf("expected pass-through, got %q", got)
 	}
 }
 
 func TestGetMimeType(t *testing.T) {
-	tool := createTestTool()
+	tool := newTestTool(t)
 
 	tests := []struct {
 		imageType string
@@ -363,8 +263,7 @@ func TestGetMimeType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.imageType, func(t *testing.T) {
-			result := tool.getMimeType(tt.imageType)
-			if result != tt.expected {
+			if result := tool.getMimeType(tt.imageType); result != tt.expected {
 				t.Errorf("Expected %s for %s, got %s", tt.expected, tt.imageType, result)
 			}
 		})
@@ -372,12 +271,9 @@ func TestGetMimeType(t *testing.T) {
 }
 
 func TestGetCurrentTimestamp(t *testing.T) {
-	tool := createTestTool()
-
+	tool := newTestTool(t)
 	timestamp := tool.getCurrentTimestamp()
-
-	_, err := time.Parse(time.RFC3339, timestamp)
-	if err != nil {
+	if _, err := time.Parse(time.RFC3339, timestamp); err != nil {
 		t.Errorf("Expected valid RFC3339 timestamp, got: %s (error: %v)", timestamp, err)
 	}
 }

--- a/tools/wait_for_condition.go
+++ b/tools/wait_for_condition.go
@@ -5,9 +5,16 @@ import (
 	"fmt"
 	"time"
 
-	server "github.com/inference-gateway/adk/server"
-	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
 	zap "go.uber.org/zap"
+
+	server "github.com/inference-gateway/adk/server"
+
+	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
+)
+
+var (
+	validWaitConditionTypes = []string{"selector", "navigation", "function", "timeout", "networkidle"}
+	validSelectorStates     = []string{"visible", "hidden", "attached", "detached"}
 )
 
 // WaitForConditionTool struct holds the tool with dependencies
@@ -29,7 +36,7 @@ func NewWaitForConditionTool(logger *zap.Logger, playwright playwright.BrowserAu
 			"type": "object",
 			"properties": map[string]any{
 				"condition": map[string]any{
-					"description": "Type of condition (selector, navigation, function, timeout)",
+					"description": "Type of condition (selector, navigation, function, timeout, networkidle)",
 					"type":        "string",
 				},
 				"custom_function": map[string]any{
@@ -46,7 +53,7 @@ func NewWaitForConditionTool(logger *zap.Logger, playwright playwright.BrowserAu
 					"type":        "string",
 				},
 				"timeout": map[string]any{
-					"default":     30000,
+					"default":     defaultTimeoutMs,
 					"description": "Maximum time to wait in milliseconds",
 					"type":        "integer",
 				},
@@ -57,43 +64,47 @@ func NewWaitForConditionTool(logger *zap.Logger, playwright playwright.BrowserAu
 	)
 }
 
-// WaitForConditionHandler handles the wait_for_condition tool execution
+// WaitForConditionHandler handles the wait_for_condition tool execution.
+//
+// Note on 'networkidle': previously this branch injected JavaScript that
+// permanently replaced window.fetch and window.XMLHttpRequest on the page
+// (and never restored the originals, polluting every subsequent request
+// in the same session). It is now delegated to Playwright's native
+// page.WaitForLoadState(LoadStateNetworkidle) via the playwright service,
+// which has no such side effects.
 func (s *WaitForConditionTool) WaitForConditionHandler(ctx context.Context, args map[string]any) (string, error) {
-	condition, ok := args["condition"].(string)
-	if !ok || condition == "" {
-		return "", fmt.Errorf("condition parameter is required and must be a non-empty string")
+	condition, err := requiredString(args, "condition")
+	if err != nil {
+		return "", err
+	}
+	if !oneOf(condition, validWaitConditionTypes...) {
+		return "", fmt.Errorf("invalid condition type: %s. Must be one of: %v", condition, validWaitConditionTypes)
 	}
 
-	if !s.isValidCondition(condition) {
-		return "", fmt.Errorf("invalid condition type: %s. Must be one of: selector, navigation, function, timeout, networkidle", condition)
+	selector, err := stringArg(args, "selector", "")
+	if err != nil {
+		return "", err
 	}
 
-	selector := ""
-	if sel, ok := args["selector"].(string); ok {
-		selector = sel
+	state, err := stringArg(args, "state", "visible")
+	if err != nil {
+		return "", err
+	}
+	if !oneOf(state, validSelectorStates...) {
+		return "", fmt.Errorf("invalid state: %s. Must be one of: %v", state, validSelectorStates)
 	}
 
-	state := "visible"
-	if st, ok := args["state"].(string); ok && st != "" {
-		if !s.isValidState(st) {
-			return "", fmt.Errorf("invalid state: %s. Must be one of: visible, hidden, attached, detached", st)
-		}
-		state = st
+	timeout, err := boundedIntArg(args, "timeout", defaultTimeoutMs, minTimeoutMs, maxTimeoutMs)
+	if err != nil {
+		return "", err
 	}
 
-	timeout := 30000
-	if t, ok := args["timeout"].(int); ok && t > 0 {
-		timeout = t
-	} else if tf, ok := args["timeout"].(float64); ok && tf > 0 {
-		timeout = int(tf)
+	customFunction, err := stringArg(args, "custom_function", "")
+	if err != nil {
+		return "", err
 	}
 
-	customFunction := ""
-	if cf, ok := args["custom_function"].(string); ok {
-		customFunction = cf
-	}
-
-	if err := s.validateConditionRequirements(condition, selector, customFunction); err != nil {
+	if err := validateConditionRequirements(condition, selector, customFunction); err != nil {
 		return "", err
 	}
 
@@ -101,8 +112,7 @@ func (s *WaitForConditionTool) WaitForConditionHandler(ctx context.Context, args
 		zap.String("condition", condition),
 		zap.String("selector", selector),
 		zap.String("state", state),
-		zap.Int("timeout_ms", timeout),
-		zap.String("custom_function", customFunction))
+		zap.Int("timeout_ms", timeout))
 
 	session, err := s.playwright.GetOrCreateTaskSession(ctx)
 	if err != nil {
@@ -113,8 +123,7 @@ func (s *WaitForConditionTool) WaitForConditionHandler(ctx context.Context, args
 	timeoutDuration := time.Duration(timeout) * time.Millisecond
 	startTime := time.Now()
 
-	err = s.executeWaitCondition(ctx, session.ID, condition, selector, state, timeoutDuration, customFunction)
-	if err != nil {
+	if err := s.playwright.WaitForCondition(ctx, session.ID, condition, selector, state, timeoutDuration, customFunction); err != nil {
 		s.logger.Error("wait condition failed",
 			zap.String("condition", condition),
 			zap.String("selector", selector),
@@ -127,11 +136,10 @@ func (s *WaitForConditionTool) WaitForConditionHandler(ctx context.Context, args
 
 	s.logger.Info("wait condition completed successfully",
 		zap.String("condition", condition),
-		zap.String("selector", selector),
 		zap.String("sessionID", session.ID),
 		zap.Int64("actual_wait_ms", actualWaitTime))
 
-	response := map[string]any{
+	return marshalResponse(map[string]any{
 		"success":         true,
 		"condition":       condition,
 		"selector":        selector,
@@ -139,37 +147,15 @@ func (s *WaitForConditionTool) WaitForConditionHandler(ctx context.Context, args
 		"timeout_ms":      timeout,
 		"actual_wait_ms":  actualWaitTime,
 		"session_id":      session.ID,
-		"message":         "Wait condition completed successfully",
 		"custom_function": customFunction,
-	}
-
-	return fmt.Sprintf(`%+v`, response), nil
+		"message":         "Wait condition completed successfully",
+	})
 }
 
-// isValidCondition validates the condition type
-func (s *WaitForConditionTool) isValidCondition(condition string) bool {
-	validConditions := []string{"selector", "navigation", "function", "timeout", "networkidle"}
-	for _, valid := range validConditions {
-		if condition == valid {
-			return true
-		}
-	}
-	return false
-}
-
-// isValidState validates the selector state
-func (s *WaitForConditionTool) isValidState(state string) bool {
-	validStates := []string{"visible", "hidden", "attached", "detached"}
-	for _, valid := range validStates {
-		if state == valid {
-			return true
-		}
-	}
-	return false
-}
-
-// validateConditionRequirements validates condition-specific requirements
-func (s *WaitForConditionTool) validateConditionRequirements(condition, selector, customFunction string) error {
+// validateConditionRequirements validates condition-specific requirements.
+// Standalone function (not a method) so it can be called from tests without
+// constructing a tool.
+func validateConditionRequirements(condition, selector, customFunction string) error {
 	switch condition {
 	case "selector":
 		if selector == "" {
@@ -179,70 +165,6 @@ func (s *WaitForConditionTool) validateConditionRequirements(condition, selector
 		if customFunction == "" {
 			return fmt.Errorf("custom_function parameter is required for function condition")
 		}
-	case "navigation", "timeout", "networkidle":
 	}
 	return nil
-}
-
-// executeWaitCondition executes the appropriate wait operation based on condition type
-func (s *WaitForConditionTool) executeWaitCondition(ctx context.Context, sessionID, condition, selector, state string, timeout time.Duration, customFunction string) error {
-	switch condition {
-	case "selector":
-		return s.playwright.WaitForCondition(ctx, sessionID, condition, selector, state, timeout, "")
-	case "function":
-		return s.playwright.WaitForCondition(ctx, sessionID, condition, "", "", timeout, customFunction)
-	case "navigation":
-		return s.playwright.WaitForCondition(ctx, sessionID, condition, "", "", timeout, "")
-	case "timeout":
-		return s.playwright.WaitForCondition(ctx, sessionID, condition, "", "", timeout, "")
-	case "networkidle":
-		networkIdleFunction := `
-			() => {
-				return new Promise((resolve) => {
-					let timeout;
-					let requestCount = 0;
-					
-					// Monitor fetch requests
-					const originalFetch = window.fetch;
-					window.fetch = function(...args) {
-						requestCount++;
-						return originalFetch.apply(this, args).finally(() => {
-							requestCount--;
-							if (requestCount === 0) {
-								clearTimeout(timeout);
-								timeout = setTimeout(() => resolve(true), 500);
-							}
-						});
-					};
-					
-					// Monitor XMLHttpRequest
-					const originalXHR = window.XMLHttpRequest;
-					window.XMLHttpRequest = function() {
-						const xhr = new originalXHR();
-						const originalSend = xhr.send;
-						xhr.send = function(...args) {
-							requestCount++;
-							xhr.addEventListener('loadend', () => {
-								requestCount--;
-								if (requestCount === 0) {
-									clearTimeout(timeout);
-									timeout = setTimeout(() => resolve(true), 500);
-								}
-							});
-							return originalSend.apply(this, args);
-						};
-						return xhr;
-					};
-					
-					// Initial check
-					if (requestCount === 0) {
-						timeout = setTimeout(() => resolve(true), 500);
-					}
-				});
-			}
-		`
-		return s.playwright.WaitForCondition(ctx, sessionID, "function", "", "", timeout, networkIdleFunction)
-	default:
-		return fmt.Errorf("unsupported condition type: %s", condition)
-	}
 }

--- a/tools/wait_for_condition_test.go
+++ b/tools/wait_for_condition_test.go
@@ -2,13 +2,16 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
+	zap "go.uber.org/zap"
 
-	"github.com/inference-gateway/browser-agent/internal/playwright"
-	"github.com/inference-gateway/browser-agent/internal/playwright/mocks"
+	assert "github.com/stretchr/testify/assert"
+
+	mocks "github.com/inference-gateway/browser-agent/internal/playwright/mocks"
+
+	playwright "github.com/inference-gateway/browser-agent/internal/playwright"
 )
 
 func TestWaitForConditionTool_NewWaitForConditionTool(t *testing.T) {
@@ -20,73 +23,7 @@ func TestWaitForConditionTool_NewWaitForConditionTool(t *testing.T) {
 	assert.NotNil(t, tool)
 }
 
-func TestWaitForConditionTool_ValidateCondition(t *testing.T) {
-	logger := zap.NewNop()
-	mockPlaywright := &mocks.FakeBrowserAutomation{}
-	tool := &WaitForConditionTool{
-		logger:     logger,
-		playwright: mockPlaywright,
-	}
-
-	tests := []struct {
-		name      string
-		condition string
-		expected  bool
-	}{
-		{"valid selector", "selector", true},
-		{"valid navigation", "navigation", true},
-		{"valid function", "function", true},
-		{"valid timeout", "timeout", true},
-		{"valid networkidle", "networkidle", true},
-		{"invalid condition", "invalid", false},
-		{"empty condition", "", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := tool.isValidCondition(tt.condition)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestWaitForConditionTool_ValidateState(t *testing.T) {
-	logger := zap.NewNop()
-	mockPlaywright := &mocks.FakeBrowserAutomation{}
-	tool := &WaitForConditionTool{
-		logger:     logger,
-		playwright: mockPlaywright,
-	}
-
-	tests := []struct {
-		name     string
-		state    string
-		expected bool
-	}{
-		{"valid visible", "visible", true},
-		{"valid hidden", "hidden", true},
-		{"valid attached", "attached", true},
-		{"valid detached", "detached", true},
-		{"invalid state", "invalid", false},
-		{"empty state", "", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := tool.isValidState(tt.state)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestWaitForConditionTool_ValidateConditionRequirements(t *testing.T) {
-	logger := zap.NewNop()
-	mockPlaywright := &mocks.FakeBrowserAutomation{}
-	tool := &WaitForConditionTool{
-		logger:     logger,
-		playwright: mockPlaywright,
-	}
-
 	tests := []struct {
 		name           string
 		condition      string
@@ -105,7 +42,7 @@ func TestWaitForConditionTool_ValidateConditionRequirements(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tool.validateConditionRequirements(tt.condition, tt.selector, tt.customFunction)
+			err := validateConditionRequirements(tt.condition, tt.selector, tt.customFunction)
 			if tt.shouldError {
 				assert.Error(t, err)
 			} else {
@@ -123,10 +60,7 @@ func TestWaitForConditionTool_WaitForConditionHandler_Success(t *testing.T) {
 		playwright: mockPlaywright,
 	}
 
-	session := &playwright.BrowserSession{
-		ID: "test-session",
-	}
-
+	session := &playwright.BrowserSession{ID: "test-session"}
 	mockPlaywright.GetOrCreateTaskSessionReturns(session, nil)
 	mockPlaywright.WaitForConditionReturns(nil)
 
@@ -140,25 +74,22 @@ func TestWaitForConditionTool_WaitForConditionHandler_Success(t *testing.T) {
 	result, err := tool.WaitForConditionHandler(context.Background(), args)
 
 	assert.NoError(t, err)
-	assert.Contains(t, result, "success:true")
-	assert.Contains(t, result, "condition:selector")
-	assert.Contains(t, result, "selector:.button")
+	var parsed map[string]any
+	assert.NoError(t, json.Unmarshal([]byte(result), &parsed), "response should be valid JSON")
+	assert.Equal(t, true, parsed["success"])
+	assert.Equal(t, "selector", parsed["condition"])
+	assert.Equal(t, ".button", parsed["selector"])
 }
 
 func TestWaitForConditionTool_WaitForConditionHandler_MissingCondition(t *testing.T) {
-	logger := zap.NewNop()
-	mockPlaywright := &mocks.FakeBrowserAutomation{}
 	tool := &WaitForConditionTool{
-		logger:     logger,
-		playwright: mockPlaywright,
+		logger:     zap.NewNop(),
+		playwright: &mocks.FakeBrowserAutomation{},
 	}
-
-	args := map[string]any{
+	result, err := tool.WaitForConditionHandler(context.Background(), map[string]any{
 		"selector": ".button",
 		"state":    "visible",
-	}
-
-	result, err := tool.WaitForConditionHandler(context.Background(), args)
+	})
 
 	assert.Error(t, err)
 	assert.Empty(t, result)
@@ -166,19 +97,14 @@ func TestWaitForConditionTool_WaitForConditionHandler_MissingCondition(t *testin
 }
 
 func TestWaitForConditionTool_WaitForConditionHandler_InvalidCondition(t *testing.T) {
-	logger := zap.NewNop()
-	mockPlaywright := &mocks.FakeBrowserAutomation{}
 	tool := &WaitForConditionTool{
-		logger:     logger,
-		playwright: mockPlaywright,
+		logger:     zap.NewNop(),
+		playwright: &mocks.FakeBrowserAutomation{},
 	}
-
-	args := map[string]any{
+	result, err := tool.WaitForConditionHandler(context.Background(), map[string]any{
 		"condition": "invalid",
 		"selector":  ".button",
-	}
-
-	result, err := tool.WaitForConditionHandler(context.Background(), args)
+	})
 
 	assert.Error(t, err)
 	assert.Empty(t, result)
@@ -186,20 +112,15 @@ func TestWaitForConditionTool_WaitForConditionHandler_InvalidCondition(t *testin
 }
 
 func TestWaitForConditionTool_WaitForConditionHandler_InvalidState(t *testing.T) {
-	logger := zap.NewNop()
-	mockPlaywright := &mocks.FakeBrowserAutomation{}
 	tool := &WaitForConditionTool{
-		logger:     logger,
-		playwright: mockPlaywright,
+		logger:     zap.NewNop(),
+		playwright: &mocks.FakeBrowserAutomation{},
 	}
-
-	args := map[string]any{
+	result, err := tool.WaitForConditionHandler(context.Background(), map[string]any{
 		"condition": "selector",
 		"selector":  ".button",
 		"state":     "invalid",
-	}
-
-	result, err := tool.WaitForConditionHandler(context.Background(), args)
+	})
 
 	assert.Error(t, err)
 	assert.Empty(t, result)
@@ -207,19 +128,14 @@ func TestWaitForConditionTool_WaitForConditionHandler_InvalidState(t *testing.T)
 }
 
 func TestWaitForConditionTool_WaitForConditionHandler_SelectorWithoutSelector(t *testing.T) {
-	logger := zap.NewNop()
-	mockPlaywright := &mocks.FakeBrowserAutomation{}
 	tool := &WaitForConditionTool{
-		logger:     logger,
-		playwright: mockPlaywright,
+		logger:     zap.NewNop(),
+		playwright: &mocks.FakeBrowserAutomation{},
 	}
-
-	args := map[string]any{
+	result, err := tool.WaitForConditionHandler(context.Background(), map[string]any{
 		"condition": "selector",
 		"state":     "visible",
-	}
-
-	result, err := tool.WaitForConditionHandler(context.Background(), args)
+	})
 
 	assert.Error(t, err)
 	assert.Empty(t, result)
@@ -227,18 +143,13 @@ func TestWaitForConditionTool_WaitForConditionHandler_SelectorWithoutSelector(t 
 }
 
 func TestWaitForConditionTool_WaitForConditionHandler_FunctionWithoutFunction(t *testing.T) {
-	logger := zap.NewNop()
-	mockPlaywright := &mocks.FakeBrowserAutomation{}
 	tool := &WaitForConditionTool{
-		logger:     logger,
-		playwright: mockPlaywright,
+		logger:     zap.NewNop(),
+		playwright: &mocks.FakeBrowserAutomation{},
 	}
-
-	args := map[string]any{
+	result, err := tool.WaitForConditionHandler(context.Background(), map[string]any{
 		"condition": "function",
-	}
-
-	result, err := tool.WaitForConditionHandler(context.Background(), args)
+	})
 
 	assert.Error(t, err)
 	assert.Empty(t, result)
@@ -253,22 +164,46 @@ func TestWaitForConditionTool_WaitForConditionHandler_DefaultValues(t *testing.T
 		playwright: mockPlaywright,
 	}
 
-	session := &playwright.BrowserSession{
-		ID: "test-session",
-	}
-
+	session := &playwright.BrowserSession{ID: "test-session"}
 	mockPlaywright.GetOrCreateTaskSessionReturns(session, nil)
 	mockPlaywright.WaitForConditionReturns(nil)
 
-	args := map[string]any{
+	result, err := tool.WaitForConditionHandler(context.Background(), map[string]any{
 		"condition": "selector",
 		"selector":  ".button",
-	}
-
-	result, err := tool.WaitForConditionHandler(context.Background(), args)
+	})
 
 	assert.NoError(t, err)
-	assert.Contains(t, result, "success:true")
-	assert.Contains(t, result, "state:visible")
-	assert.Contains(t, result, "timeout_ms:30000")
+	var parsed map[string]any
+	assert.NoError(t, json.Unmarshal([]byte(result), &parsed))
+	assert.Equal(t, true, parsed["success"])
+	assert.Equal(t, "visible", parsed["state"])
+	assert.Equal(t, float64(defaultTimeoutMs), parsed["timeout_ms"])
+}
+
+// TestWaitForConditionTool_NetworkidleDoesNotInjectJS confirms that the
+// networkidle branch is delegated to the playwright service as-is, with
+// an empty customFunction. Previously the tool emitted a hand-rolled JS
+// blob that monkey-patched window.fetch / window.XMLHttpRequest and never
+// restored them.
+func TestWaitForConditionTool_NetworkidleDoesNotInjectJS(t *testing.T) {
+	logger := zap.NewNop()
+	mockPlaywright := &mocks.FakeBrowserAutomation{}
+	session := &playwright.BrowserSession{ID: "test-session"}
+	mockPlaywright.GetOrCreateTaskSessionReturns(session, nil)
+	mockPlaywright.WaitForConditionReturns(nil)
+
+	tool := &WaitForConditionTool{logger: logger, playwright: mockPlaywright}
+	_, err := tool.WaitForConditionHandler(context.Background(), map[string]any{
+		"condition": "networkidle",
+		"timeout":   1000,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, mockPlaywright.WaitForConditionCallCount())
+
+	_, _, gotCondition, _, _, _, gotCustomFn := mockPlaywright.WaitForConditionArgsForCall(0)
+	assert.Equal(t, "networkidle", gotCondition,
+		"networkidle should pass through as the condition name, not be rewritten to 'function'")
+	assert.Empty(t, gotCustomFn, "no custom JS should be injected for networkidle")
 }


### PR DESCRIPTION
## Summary

Sweep across the manually-implemented browser tools to fix correctness bugs surfaced during review and collapse the boilerplate they accumulated. **Net −538 lines** (1139 inserted, 1444 deleted) across 19 files.

### Correctness bugs fixed
- **JSON output across all tools** - `navigate_to_url`, `click_element`, `fill_form`, `wait_for_condition` no longer emit Go's `%+v` debug format (e.g. `map[success:true ...]`). All responses now go through `json.Marshal` via a shared `marshalResponse` helper. The LLM consumer was getting malformed JSON before.
- **`handle_authentication` silent no-op** - previously returned `{"result":"TODO: ..."}` with `err == nil`, so callers saw a fake success. Now returns an explicit `not yet implemented` error with guidance on composing the same flow from `navigate_to_url` + `fill_form` + `click_element`.
- **`wait_for_condition` networkidle pollution** - the hand-rolled JS was overwriting `window.fetch` and `window.XMLHttpRequest` and never restoring them, breaking every subsequent fetch/XHR on the page. Replaced with Playwright's native `page.WaitForLoadState(LoadStateNetworkidle)`.
- **`fill_form` N round-trips** - was re-calling `FillForm` once per field and clicking submit through `ClickElement` with a mismatched timeout type. Collapsed into a single batched `FillForm` call (asserted via `FillFormCallCount() == 1`).
- **Negative numeric args silently defaulting** - `timeout: -5` used to become `30000`. `boundedIntArg` now rejects out-of-range values with an explicit error.
- **`click_element` `force` flag ignored** - flag was accepted but the code still required visibility first. Now `force=true` skips the actionability wait, matching the documented intent.
- **`text=` selector false-positive** - `Contains(selector, "text=")` matched `[data-text="..."]`. Replaced with `HasPrefix`/Playwright pseudo-class detection.
- **`execute_script` regex false-positives** - `\bglobal\.`, `\bprocess\.`, `\bexec\(`, `\bspawn\(`, `\beval\(`, `\bFunction\(`, `\b__dirname` etc. matched dotted property access (`obj.process.x`, `arr.exec(re)`). Prefixed with `(?:^|[^.\w])` so member access passes. Script body no longer logged at ERROR level - hash + length only, to avoid leaking secrets.
- **`internal/playwright.ExtractData`** - was returning `fmt.Sprintf("%+v", results)` regardless of the requested `format`. Now returns canonical JSON, which is what enabled the `extract_data` parser cleanup below.

### Quality / robustness
- New **`tools/args.go`** centralises `requiredString`, `stringArg`, `boolArg`, `intArg`, `boundedIntArg`, `sliceArg`, `oneOf`, `marshalResponse` plus all default/min/max constants. Removes the duplicated int/float/default arg-parsing dance from 7 tools.
- **`extract_data`** drops ~140 lines of `parseGoMapFormat` / `smartSplit` / `isNextKeyStart` / `parseValue` / `parseScalarValue` / `extractDataFromString` - only existed because the service was emitting `%+v`.
- Hot-path **regexes hoisted** to package vars (`whitespaceRun`, `controlChars`, `textSelectorPrefixes`).
- **`take_screenshot`** filename truncation now slices by runes via `truncateRunes()` so multibyte selectors don't produce invalid-UTF-8 filenames.
- **`take_screenshot` tests** use `t.TempDir()` instead of a hardcoded `test_screenshots` directory.
- `getResultType` covers `uint*` variants.
- `navigate_to_url` no longer shadows the imported `net/url` package.

### Out of scope (deferred follow-up)
- Screenshot bytes pipeline (avoid the `os.ReadFile` round-trip after Playwright writes the file) - requires changing the `BrowserAutomation.TakeScreenshot` interface and regenerating the counterfeiter mock. The race is theoretical (same host, microsecond gap).