### PR TITLE
docs: author spec.documentation and spec.examples in agent.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ infer agents add browser-agent http://localhost:8080 \
 | `handle_authentication` | Handle various authentication scenarios including basic auth, OAuth, and custom login forms | login_url, password, password_selector, submit_selector, type, username, username_selector |
 | `wait_for_condition` | Wait for specific conditions before proceeding with automation | condition, custom_function, selector, state, timeout |
 
+## Examples
+
+| Example | Description |
+|---------|-------------|
+| End-to-end webapp testing | Ask the agent to verify a web app flow. It navigates to the page, screenshots the rendered DOM to discover selectors, then drives the flow with navigate_to_url, click_element, fill_form, and wait_for_condition, capturing a screenshot at each checkpoint. |
+| Structured web scraping | Point the agent at one or more (optionally paginated) pages. It uses extract_data to pull fields into structured records, normalizes them, and writes a downloadable JSON or CSV artifact via the write tool. |
+| Authenticated form automation | Hand the agent a multi-step form behind a login. It chains handle_authentication, fill_form, and click_element, waits for the post-submit state with wait_for_condition, and returns a screenshot of the confirmation page. |
+| Cited deep research | Give the agent an open-ended question. It plans sub-questions, drives a search engine, cross-references multiple sources with navigate_to_url and extract_data, and writes a cited Markdown report with the write tool. |
+
 ## Skills (loaded into the system prompt)
 
 | Skill | Description | Source |
@@ -91,6 +100,12 @@ infer agents add browser-agent http://localhost:8080 \
 | `web-scraping` | Use this when the user asks to extract structured data from one or more pages. Drives extract_data across paginated URLs, normalizes results, and writes a JSON/CSV artifact via the write tool. | bare scaffold (`skills/web-scraping.md`) |
 | `form-automation` | Use this when the user asks to complete a multi-step form, optionally behind a login. Orchestrates handle_authentication, navigate_to_url, fill_form, click_element, wait_for_condition, and take_screenshot to capture the post-submit confirmation. | bare scaffold (`skills/form-automation.md`) |
 | `deep-research` | Use this when the user asks an open-ended question that needs synthesis from multiple web sources. Plans sub-questions, drives a search engine, visits and cross-references sources via navigate_to_url + extract_data, and writes a cited markdown report with write. | bare scaffold (`skills/deep-research.md`) |
+
+## Documentation
+- [Getting Started](docs/getting-started.md)
+- [Configuration](docs/configuration.md)
+- [Usage](docs/usage.md)
+- [Playwright Service](docs/playwright-service.md)
 
 ## Configuration
 

--- a/agent.yaml
+++ b/agent.yaml
@@ -488,6 +488,43 @@ spec:
     dependabot: true
     ci: true
     cd: true
+  documentation:
+    pages:
+      - title: Getting Started
+        path: docs/getting-started.md
+        description: Build, run, and verify the agent locally or with Docker.
+      - title: Configuration
+        path: docs/configuration.md
+        description: Environment variables for the LLM provider, server, browser, and tools.
+      - title: Usage
+        path: docs/usage.md
+        description: Submitting tasks and driving the agent's tools and skills.
+      - title: Playwright Service
+        path: docs/playwright-service.md
+        description: The browser-automation service that backs the agent's tools.
+  examples:
+    - title: End-to-end webapp testing
+      description: >-
+        Ask the agent to verify a web app flow. It navigates to the page,
+        screenshots the rendered DOM to discover selectors, then drives the flow
+        with navigate_to_url, click_element, fill_form, and wait_for_condition,
+        capturing a screenshot at each checkpoint.
+    - title: Structured web scraping
+      description: >-
+        Point the agent at one or more (optionally paginated) pages. It uses
+        extract_data to pull fields into structured records, normalizes them,
+        and writes a downloadable JSON or CSV artifact via the write tool.
+    - title: Authenticated form automation
+      description: >-
+        Hand the agent a multi-step form behind a login. It chains
+        handle_authentication, fill_form, and click_element, waits for the
+        post-submit state with wait_for_condition, and returns a screenshot of
+        the confirmation page.
+    - title: Cited deep research
+      description: >-
+        Give the agent an open-ended question. It plans sub-questions, drives a
+        search engine, cross-references multiple sources with navigate_to_url
+        and extract_data, and writes a cited Markdown report with the write tool.
   artifacts:
     enabled: true
   development:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,74 @@
+# Configuration
+
+`browser-agent` is configured entirely through environment variables. Defaults
+are derived from `spec.config.*` in `agent.yaml`; the variables below override
+them at runtime. This page lists the settings most relevant to this agent — see
+the generated `README.md` for the exhaustive table.
+
+## LLM provider
+
+The agent uses an OpenAI-compatible LLM client.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `A2A_AGENT_CLIENT_PROVIDER` | Provider: `openai`, `anthropic`, `azure`, `ollama`, `deepseek` | – |
+| `A2A_AGENT_CLIENT_MODEL` | Model identifier | – |
+| `A2A_AGENT_CLIENT_API_KEY` | API key for the provider | – |
+| `A2A_AGENT_CLIENT_BASE_URL` | Custom endpoint (e.g. the Inference Gateway) | – |
+| `A2A_AGENT_CLIENT_MAX_TOKENS` | Max tokens per response | `4096` |
+| `A2A_AGENT_CLIENT_TEMPERATURE` | Sampling temperature | `0.7` |
+
+## Server
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `A2A_PORT` / `A2A_SERVER_PORT` | Server port | `8080` |
+| `A2A_DEBUG` | Enable debug logging | `false` |
+| `A2A_STREAMING_STATUS_UPDATE_INTERVAL` | Streaming status update frequency | `1s` |
+
+## Browser
+
+These map to `spec.config.browser` and control the Playwright runtime.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `BROWSER_ENGINE` | Browser engine: `chromium`, `firefox`, `webkit` | `chromium` |
+| `BROWSER_HEADLESS` | Run headless | `true` |
+| `BROWSER_STEALTH_MODE` | Enable stealth patches | `false` |
+| `BROWSER_SESSION_TIMEOUT` | Idle session timeout | `2m` |
+| `BROWSER_VIEWPORT_WIDTH` | Viewport width | `1920` |
+| `BROWSER_VIEWPORT_HEIGHT` | Viewport height | `1080` |
+| `BROWSER_USER_AGENT` | User-Agent header | Chrome 131 UA |
+| `BROWSER_DATA_DIR` | Scratch/artifacts directory | `/tmp/playwright/artifacts` |
+| `BROWSER_XVFB_ENABLED` | Run under Xvfb (for headed mode on a headless host) | `false` |
+
+## Built-in tools
+
+The `read`, `write`, `edit`, and `fetch` tools are toggled and tuned here.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TOOLS_READ_ENABLED` | Enable the `read` tool | `true` |
+| `TOOLS_READ_MAX_LINES` | Default read slice | `2000` |
+| `TOOLS_WRITE_ENABLED` | Enable the `write` tool | `true` |
+| `TOOLS_EDIT_ENABLED` | Enable the `edit` tool | `true` |
+| `TOOLS_FETCH_ENABLED` | Enable the `fetch` tool | `true` |
+| `TOOLS_FETCH_ALLOW_DOWNLOADS` | Allow `fetch` to save response bodies | `true` |
+| `TOOLS_FETCH_DOWNLOAD_DIR` | Download directory for `fetch` | `/tmp/playwright/artifacts` |
+
+## Artifacts
+
+Screenshots and extracted data are saved as downloadable artifacts. Enable the
+artifacts server with `A2A_ARTIFACTS_ENABLE=true` (`filesystem` and `minio`
+backends are supported). See the `README.md` for the full `A2A_ARTIFACTS_*`
+table.
+
+## Example `.env`
+
+```bash
+A2A_AGENT_CLIENT_PROVIDER=openai
+A2A_AGENT_CLIENT_MODEL=gpt-4o
+A2A_AGENT_CLIENT_API_KEY=sk-...
+A2A_DEBUG=true
+BROWSER_HEADLESS=true
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,72 @@
+# Getting Started
+
+`browser-agent` is an A2A (Agent-to-Agent) server that drives a real
+[Playwright](https://playwright.dev/) browser to automate web tasks. This page
+covers building and running it locally.
+
+## Prerequisites
+
+- Go 1.26.4+ (only if building/running from source)
+- A Chromium/Firefox/WebKit runtime for Playwright. The provided `Dockerfile`
+  ships the browsers preinstalled — this is the simplest way to run the agent.
+- An OpenAI-compatible LLM endpoint and credentials (see
+  [Configuration](configuration.md)).
+
+## Run from source
+
+```bash
+# Start the A2A server (defaults to port 8080)
+go run . start
+
+# Or build the CLI and invoke it directly
+task build
+./bin/browser-agent --help
+./bin/browser-agent --version
+./bin/browser-agent start
+```
+
+The binary is a [Cobra](https://github.com/spf13/cobra) CLI. The root command
+exposes `--help` and `--version`; the `start` subcommand boots the server and
+blocks until it receives `SIGINT`/`SIGTERM`.
+
+## Run with Docker
+
+```bash
+docker build -t browser-agent .
+docker run -p 8080:8080 browser-agent
+```
+
+## Run the local stack
+
+A `docker-compose.yaml` brings up the Inference Gateway alongside the agent
+(built from the local `Dockerfile`, so code changes are picked up):
+
+```bash
+docker compose up --build
+```
+
+Opt-in profiles add the `infer` CLI and the `a2a-debugger`:
+
+```bash
+docker compose --profile cli run --rm cli chat
+docker compose --profile debugger run --rm debugger \
+  --server-url http://browser-agent:8080 tasks submit "What are your skills?"
+```
+
+## Verify it is running
+
+```bash
+# Health check
+curl http://localhost:8080/health
+
+# Agent metadata (capabilities, tools, skills)
+curl http://localhost:8080/.well-known/agent-card.json
+```
+
+## Next steps
+
+- [Configuration](configuration.md) — environment variables, LLM provider, and
+  browser settings.
+- [Usage](usage.md) — submitting tasks and driving the agent.
+- [Playwright Service](playwright-service.md) — the browser-automation service
+  that backs the tools.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,76 @@
+# Usage
+
+Once the agent is running (see [Getting Started](getting-started.md)), you drive
+it by submitting A2A tasks in natural language. The agent plans the work,
+selects tools, and streams progress back.
+
+## Submitting a task
+
+The quickest way to exercise the agent is the
+[A2A Debugger](https://github.com/inference-gateway/a2a-debugger):
+
+```bash
+docker run --rm -it --network host \
+  ghcr.io/inference-gateway/a2a-debugger:latest \
+  --server-url http://localhost:8080 \
+  tasks submit "Go to https://example.com and take a full-page screenshot"
+
+# List tasks and inspect a result
+docker run --rm -it --network host \
+  ghcr.io/inference-gateway/a2a-debugger:latest \
+  --server-url http://localhost:8080 tasks list
+docker run --rm -it --network host \
+  ghcr.io/inference-gateway/a2a-debugger:latest \
+  --server-url http://localhost:8080 tasks get <task-id>
+```
+
+You can also submit directly over the A2A protocol at `POST /a2a`, or wire the
+agent into the `infer` CLI (see the `cli` profile in `docker-compose.yaml`).
+
+## What the agent can do
+
+The agent exposes browser-automation tools and a set of skill playbooks it loads
+on demand.
+
+### Tools
+
+| Tool | Purpose |
+|------|---------|
+| `navigate_to_url` | Load a URL and wait for the page |
+| `click_element` | Click by CSS selector, XPath, or text |
+| `fill_form` | Fill and optionally submit form fields |
+| `extract_data` | Pull structured data out of the DOM |
+| `take_screenshot` | Capture the page or a single element |
+| `execute_script` | Run JavaScript in the page (browser context only) |
+| `handle_authentication` | Basic auth, form login, or OAuth flows |
+| `wait_for_condition` | Wait for a selector, navigation, or custom predicate |
+| `read` / `write` / `edit` | Work with local files (e.g. save artifacts) |
+| `fetch` | Fast HTTP(S) GET/HEAD without a browser session |
+
+> **Tip:** For static content (raw files, JSON/XML APIs, feeds, downloads) the
+> agent prefers `fetch` over `navigate_to_url` — it is much faster and opens no
+> browser session. Browser tools are reserved for JavaScript-rendered pages and
+> stateful, authenticated sessions.
+
+### Skills
+
+| Skill | When it triggers |
+|-------|------------------|
+| `webapp-testing` | Verify/validate/test a webapp end-to-end |
+| `web-scraping` | Extract structured data across one or more pages |
+| `form-automation` | Complete a multi-step form, optionally behind a login |
+| `deep-research` | Synthesize an answer from multiple web sources |
+
+## Example prompts
+
+- "Test the login flow on `https://staging.example.com` with user `demo` and
+  screenshot the dashboard after signing in."
+- "Scrape every product title and price from the three catalog pages and save
+  them as a CSV."
+- "Fill the multi-step signup form at `<url>`, submit it, and capture the
+  confirmation page."
+- "Research the current state of the WebGPU spec across the official sources and
+  write a cited Markdown report."
+
+Screenshots and extracted data are returned as downloadable artifacts when the
+artifacts server is enabled (`A2A_ARTIFACTS_ENABLE=true`).


### PR DESCRIPTION
Adds spec.examples and spec.documentation.pages to agent.yaml plus hand-written docs pages under docs/, and regenerates the README so the Documentation and Examples sections render.

spec.tools, spec.skills, spec.config, and spec.services are unchanged. adl validate agent.yaml passes.

Closes #118

Generated with [Claude Code](https://claude.ai/code)