### PR TITLE
fix: copy and load skills from .agents/skills

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN mkdir -p /home/agent/.cache && \
     chown -R agent:a2a /home/agent
 
 # Copy skills directory so loadSkillsManifest can read SKILL.md at runtime
-COPY --from=builder /app/skills ./skills
+COPY --from=builder /app/.agents/skills ./.agents/skills
 
 # Change ownership to agent user
 RUN chown -R agent:a2a /app

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ var (
 
 // skillsDir is the directory the runtime scans for skill manifests at
 // startup. Override with A2A_SKILLS_DIR.
-const skillsDir = "skills"
+const skillsDir = ".agents/skills"
 
 // loadSkillsManifest walks the configured skills directory, reads each
 // <skill>/SKILL.md, extracts the YAML frontmatter (name + description),


### PR DESCRIPTION
## Problem

CD fails at the **Create a release if needed** step — the Docker build errors with:

```
ERROR: failed to compute cache key: failed to calculate checksum of ref ...: "/app/skills": not found
```

Run: https://github.com/inference-gateway/browser-agent/actions/runs/30010777624/job/89218003816

## Root cause

Skills moved org-wide from `skills/` to `.agents/skills/` (open-standard layout; adl-cli PR #308). This repo's `Dockerfile` and `main.go` carry custom Playwright/xvfb modifications and are listed in `.adl-ignore`, so `adl generate` intentionally skips them — and they kept pointing at the old `skills/` path. The skill files already live at `.agents/skills/{deep-research,form-automation,web-scraping,webapp-testing}/`.

## Fix

- **`Dockerfile`**: `COPY --from=builder /app/skills ./skills` → `/app/.agents/skills ./.agents/skills` (fixes the build).
- **`main.go`**: `const skillsDir = "skills"` → `.agents/skills` — so the runtime actually loads the skills. There is no `A2A_SKILLS_DIR` override in the entrypoint/compose, so this const is authoritative; without it the build would go green but the agent would log *"failed to load skills manifest, continuing without them"*.

No compat shim — both move fully to `.agents/skills`.

## Verification

- `go build ./...` passes.
- A scoped two-stage Docker build reproducing the exact failing `COPY` resolves and lands all four skills in the image.
