### PR TITLE
fix: migrate to mxschmitt/playwright-go fork to fix retired driver CDN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 # Install playwright CLI with right version for later use
-RUN PWGO_VER=$(grep -oE "playwright-go v[0-9]+\.[0-9]+\.[0-9]+" /app/go.mod | sed 's/playwright-go v//g') \
-    && go install github.com/playwright-community/playwright-go/cmd/playwright@v${PWGO_VER}
+RUN PWGO_VER=$(grep -oE "mxschmitt/playwright-go v[0-9]+\.[0-9]+\.[0-9]+" /app/go.mod | sed 's#.*/playwright-go v##') \
+    && go install github.com/mxschmitt/playwright-go/cmd/playwright@v${PWGO_VER}
 
 # Copy source code
 COPY . .

--- a/agent.yaml
+++ b/agent.yaml
@@ -499,7 +499,7 @@ spec:
       version: "1.26.4"
       vendor:
         deps:
-          - github.com/playwright-community/playwright-go@v0.6000.0
+          - github.com/mxschmitt/playwright-go@v0.6100.0
           - github.com/jonfriesen/playwright-go-stealth@v0.0.3
           - github.com/stretchr/testify@v1.11.1
         devdeps:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 require (
 	github.com/inference-gateway/adk v0.24.0
 	github.com/jonfriesen/playwright-go-stealth v0.0.3
-	github.com/playwright-community/playwright-go v0.6000.0
+	github.com/mxschmitt/playwright-go v0.6100.0
 	github.com/sethvargo/go-envconfig v1.4.3
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
@@ -69,6 +69,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/playwright-community/playwright-go v0.6000.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.24.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxschmitt/playwright-go v0.6100.0 h1:HYNnbGZsTHz8veJyDGe4fU1iPxfvXqzmwKchzuvGCsY=
+github.com/mxschmitt/playwright-go v0.6100.0/go.mod h1:A7VtrS3j/c8ToGnSVUaOfNtQQVxi6JotUS0jeuus6r4=
 github.com/oapi-codegen/nullable v1.1.0 h1:eAh8JVc5430VtYVnq00Hrbpag9PFRGWLjxR1/3KntMs=
 github.com/oapi-codegen/nullable v1.1.0/go.mod h1:KUZ3vUzkmEKY90ksAmit2+5juDIhIZhfDl+0PwOQlFY=
 github.com/oapi-codegen/runtime v1.5.0 h1:aiil4QnH+eiWYSO60eaYZ4aur7sJH3rz6BvT5EBFnxc=

--- a/internal/playwright/playwright.go
+++ b/internal/playwright/playwright.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	stealth "github.com/jonfriesen/playwright-go-stealth"
-	playwright "github.com/playwright-community/playwright-go"
+	playwright "github.com/mxschmitt/playwright-go"
 	zap "go.uber.org/zap"
 
 	server "github.com/inference-gateway/adk/server"
@@ -289,7 +289,7 @@ func (p *playwrightImpl) LaunchBrowser(ctx context.Context, config *BrowserConfi
 	}
 
 	if p.config.Browser.StealthMode {
-		if err := stealth.Inject(page); err != nil {
+		if err := page.AddInitScript(playwright.Script{Content: playwright.String(stealth.StealthJS)}); err != nil {
 			p.logger.Warn("failed to inject stealth script", zap.Error(err))
 		} else {
 			p.logger.Info("stealth mode enabled - stealth script injected")
@@ -441,7 +441,7 @@ func (p *playwrightImpl) GetOrCreateTaskSession(ctx context.Context) (*BrowserSe
 	}
 
 	if p.config.Browser.StealthMode {
-		if err := stealth.Inject(page); err != nil {
+		if err := page.AddInitScript(playwright.Script{Content: playwright.String(stealth.StealthJS)}); err != nil {
 			p.logger.Warn("failed to inject stealth script", zap.Error(err))
 		} else {
 			p.logger.Info("stealth mode enabled - stealth script injected")


### PR DESCRIPTION
## Problem

CD fails at **Create a release if needed** — the Docker build errors with:

```
could not download driver: 404 (Not Found) from
https://playwright.azureedge.net/builds/driver/playwright-1.60.0-linux.zip
```

`playwright-go v0.6000.0` fetches its driver from `playwright.azureedge.net`, which **Microsoft retired**. The driver-zip is no longer hosted on any CDN (every candidate host 400/404s for every version), so there's no `PLAYWRIGHT_DOWNLOAD_HOST` to point at.

## Why not just bump `playwright-community/playwright-go`?

Its only newer tag, `v0.6100.0`, is **mis-published**: the tag's `go.mod` declares the module path as `github.com/mxschmitt/playwright-go`, so Go rejects it under the `playwright-community` import path. The correctly-tagged `v0.6100.0` lives on **`github.com/mxschmitt/playwright-go`**, which also rewrote downloads to use the **npm registry** (`playwright-core`) + **nodejs.org** instead of the dead CDN.

## Fix

- `agent.yaml` / `go.mod`: `playwright-community/playwright-go v0.6000.0` → `github.com/mxschmitt/playwright-go v0.6100.0`.
- `internal/playwright/playwright.go`: repoint the import to the mxschmitt fork. Replace `stealth.Inject(page)` (which pins the *playwright-community* `Page` type and would no longer type-match) with a direct `page.AddInitScript(playwright.Script{Content: playwright.String(stealth.StealthJS)})` — same stealth script, no cross-module type dependency.
- `Dockerfile`: install the CLI from the mxschmitt path and extract its version specifically (go.mod now also carries `playwright-community` transitively via `playwright-go-stealth`).

## Verification

- `go build ./...` passes.
- **Full `docker build` succeeds** — the driver resolves via npm and Chromium/FFmpeg/headless-shell download from the live `cdn.playwright.dev`; the image builds cleanly (the exact step that was 404'ing).

## Follow-up

Once `playwright-community/playwright-go` re-tags with the correct module path, we can move back to that fork via `agent.yaml` deps.
